### PR TITLE
refactor: move translation section

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -38,8 +38,6 @@ export default function Home() {
       <div className="flex flex-col gap-8">
         <ProviderSelector />
         <TextEditor />
-        <TranslationControls />
-        <TranslationHistoryPanel />
         <GenerateButton />
         <PlaybackControls />
         <ThemePanel />
@@ -54,6 +52,11 @@ export default function Home() {
           <ImportPanel />
         </div>
       </div>
+
+      <section className="flex flex-col gap-6">
+        <TranslationControls />
+        <TranslationHistoryPanel />
+      </section>
     </main>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -51,12 +51,11 @@ export default function Home() {
           <PronunciationPanel />
           <ImportPanel />
         </div>
+        <section className="flex flex-col gap-6">
+          <TranslationControls />
+          <TranslationHistoryPanel />
+        </section>
       </div>
-
-      <section className="flex flex-col gap-6">
-        <TranslationControls />
-        <TranslationHistoryPanel />
-      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- group translation controls/history into a dedicated subsection so the main editor flow stays focused
- keep translation functionality unchanged while clarifying it is optional

## Testing
- npm run lint
