### PR TITLE
refactor: use shared Convex HTTP client

### DIFF
--- a/web/src/lib/account/repository.ts
+++ b/web/src/lib/account/repository.ts
@@ -50,7 +50,7 @@ export class ConvexAccountRepository implements AccountRepository {
   }
 
   private async mutation<TArgs extends object, TResult>(
-    reference: FunctionReference<'mutation', TArgs, TResult>,
+    reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {

--- a/web/src/lib/account/repository.ts
+++ b/web/src/lib/account/repository.ts
@@ -1,3 +1,7 @@
+import type { FunctionReference } from 'convex/server';
+import { fetchMutation, type NextjsOptions } from 'convex/nextjs';
+import { api } from '../../../convex/_generated/api';
+import { buildConvexClientOptions } from '../convex/client';
 import type { AccountPayload, AccountUsageSummary } from './types';
 
 export interface AccountRepository {
@@ -10,11 +14,6 @@ interface ConvexAccountRepositoryOptions {
   baseUrl: string;
   authToken: string;
   authScheme?: string;
-  fetchImpl?: typeof fetch;
-}
-
-interface ConvexResponse<T> {
-  result: T;
 }
 
 const DEFAULT_FREE_ALLOWANCE = 50_000;
@@ -31,114 +30,57 @@ const allowanceByTier: Record<string, number> = {
 const now = () => Date.now();
 
 export class ConvexAccountRepository implements AccountRepository {
-  private readonly baseUrl: string;
-  private readonly authToken: string;
-  private readonly authScheme: string;
-  private readonly fetchImpl: typeof fetch;
+  private readonly clientOptions: NextjsOptions;
 
   constructor(options: ConvexAccountRepositoryOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/$/, '');
-    this.authToken = options.authToken;
-    this.authScheme = options.authScheme ?? 'Bearer';
-    this.fetchImpl = options.fetchImpl ?? fetch;
-  }
-
-  private async executeRequest<T>(url: string, body: unknown): Promise<T> {
-    const response = await this.fetchImpl(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `${this.authScheme} ${this.authToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const errorBody = await response.text().catch(() => '');
-      throw new Error(`Convex account request failed (${response.status}): ${errorBody}`);
-    }
-
-    if (response.status === 204) {
-      return undefined as T;
-    }
-
-    const payload = (await response.json().catch(() => ({}))) as ConvexResponse<T> | T;
-    if (payload && typeof payload === 'object' && 'result' in payload) {
-      return (payload as ConvexResponse<T>).result;
-    }
-    return payload as T;
-  }
-
-  private buildUrlCandidates(path: string): string[] {
-    const suffixes = [
-      `/api/account/${path}`,
-      `/account/${path}`,
-      `/api/http/account/${path}`,
-      `/http/account/${path}`,
-    ];
-
-    return suffixes.map((suffix) => {
-      try {
-        return new URL(suffix, this.baseUrl).toString();
-      } catch {
-        return `${this.baseUrl.replace(/\/$/, '')}${suffix}`;
-      }
+    this.clientOptions = buildConvexClientOptions({
+      baseUrl: options.baseUrl,
+      authToken: options.authToken,
+      authScheme: options.authScheme,
     });
   }
 
-  private async requestWithFallback<T>(paths: string[], body: unknown): Promise<T> {
-    let notFoundError: Error | null = null;
-    for (const path of paths) {
-      for (const url of this.buildUrlCandidates(path)) {
-        try {
-          return await this.executeRequest<T>(url, body);
-        } catch (error) {
-          const sanitizedUrl = (() => {
-            try {
-              const candidate = new URL(url);
-              return `${candidate.origin}${candidate.pathname}`;
-            } catch {
-              return url;
-            }
-          })();
-          const isNotFoundError =
-            error instanceof Error && /Convex account request failed \(404\)/.test(error.message);
-          if (isNotFoundError) {
-            console.warn('[ConvexAccountRepository] HTTP 404 when calling', sanitizedUrl);
-            notFoundError = error;
-            continue;
-          }
-          console.error('[ConvexAccountRepository] Request failed for', sanitizedUrl, error);
-          throw error;
-        }
-      }
+  private wrapError(error: unknown): Error {
+    if (error instanceof Error) {
+      const wrapped = new Error(`Convex account request failed: ${error.message}`);
+      (wrapped as Error & { cause?: unknown }).cause = error;
+      return wrapped;
     }
+    return new Error(`Convex account request failed: ${String(error)}`);
+  }
 
-    if (notFoundError) {
-      throw notFoundError;
+  private async mutation<TArgs extends object, TResult>(
+    reference: FunctionReference<'mutation', TArgs, TResult>,
+    args: TArgs,
+  ): Promise<TResult> {
+    try {
+      return await fetchMutation(reference, args, this.clientOptions);
+    } catch (error) {
+      throw this.wrapError(error);
     }
-
-    throw new Error('Convex account request failed: no routes responded successfully');
   }
 
   async getOrCreate(userId: string): Promise<AccountPayload> {
-    const result = await this.requestWithFallback<{ account: AccountPayload }>(['getOrCreate'], { userId });
+    const result = await this.mutation(api.account.getOrCreate, { userId });
+    if (!result.account) {
+      throw new Error('Convex account request failed: empty account response');
+    }
     return result.account;
   }
 
   async updateAccount(payload: AccountPayload): Promise<AccountPayload> {
-    const result = await this.requestWithFallback<{ account: AccountPayload }>(['update', 'updateAccount'], {
-      payload,
-    });
+    const result = await this.mutation(api.account.updateAccount, { payload });
+    if (!result.account) {
+      throw new Error('Convex account request failed: empty account response');
+    }
     return result.account;
   }
 
   async recordUsage(userId: string, provider: string, tokensUsed: number): Promise<AccountPayload> {
-    const result = await this.requestWithFallback<{ account: AccountPayload }>(['recordUsage'], {
-      userId,
-      provider,
-      tokensUsed,
-    });
+    const result = await this.mutation(api.account.recordUsage, { userId, provider, tokensUsed });
+    if (!result.account) {
+      throw new Error('Convex account request failed: empty account response');
+    }
     return result.account;
   }
 }

--- a/web/src/lib/account/repository.ts
+++ b/web/src/lib/account/repository.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference } from 'convex/server';
+import type { DefaultFunctionArgs, FunctionReference } from 'convex/server';
 import { fetchMutation, type NextjsOptions } from 'convex/nextjs';
 import { api } from '../../../convex/_generated/api';
 import { buildConvexClientOptions } from '../convex/client';
@@ -49,12 +49,16 @@ export class ConvexAccountRepository implements AccountRepository {
     return new Error(`Convex account request failed: ${String(error)}`);
   }
 
-  private async mutation<TArgs extends object, TResult>(
+  private async mutation<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchMutation(reference, args, this.clientOptions);
+      return (await fetchMutation(
+        reference as FunctionReference<'mutation', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
@@ -65,7 +69,7 @@ export class ConvexAccountRepository implements AccountRepository {
     if (!result.account) {
       throw new Error('Convex account request failed: empty account response');
     }
-    return result.account;
+    return result.account as AccountPayload;
   }
 
   async updateAccount(payload: AccountPayload): Promise<AccountPayload> {
@@ -73,7 +77,7 @@ export class ConvexAccountRepository implements AccountRepository {
     if (!result.account) {
       throw new Error('Convex account request failed: empty account response');
     }
-    return result.account;
+    return result.account as AccountPayload;
   }
 
   async recordUsage(userId: string, provider: string, tokensUsed: number): Promise<AccountPayload> {
@@ -81,7 +85,7 @@ export class ConvexAccountRepository implements AccountRepository {
     if (!result.account) {
       throw new Error('Convex account request failed: empty account response');
     }
-    return result.account;
+    return result.account as AccountPayload;
   }
 }
 

--- a/web/src/lib/convex/client.ts
+++ b/web/src/lib/convex/client.ts
@@ -1,0 +1,66 @@
+import type { NextjsOptions } from 'convex/nextjs';
+
+export interface ConvexClientConfig {
+  baseUrl: string;
+  authToken?: string;
+  authScheme?: string;
+}
+
+function normaliseBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+function resolveAuthKind(scheme?: string): 'admin' | 'user' | null {
+  if (!scheme) {
+    return 'admin';
+  }
+
+  const normalised = scheme.trim().toLowerCase();
+  if (!normalised) {
+    return 'admin';
+  }
+
+  if (normalised === 'bearer') {
+    return 'user';
+  }
+
+  if (normalised === 'user') {
+    return 'user';
+  }
+
+  if (normalised === 'convex') {
+    return 'admin';
+  }
+
+  if (normalised === 'deployment') {
+    return 'admin';
+  }
+
+  if (normalised === 'admin') {
+    return 'admin';
+  }
+
+  return 'admin';
+}
+
+export function buildConvexClientOptions(config: ConvexClientConfig): NextjsOptions {
+  const baseUrl = normaliseBaseUrl(config.baseUrl);
+  const authToken = config.authToken?.trim();
+  const options: NextjsOptions = {
+    url: baseUrl,
+    skipConvexDeploymentUrlCheck: true,
+  };
+
+  if (!authToken) {
+    return options;
+  }
+
+  const authKind = resolveAuthKind(config.authScheme);
+  if (authKind === 'user') {
+    options.token = authToken;
+    return options;
+  }
+
+  options.adminToken = authToken;
+  return options;
+}

--- a/web/src/lib/convex/client.ts
+++ b/web/src/lib/convex/client.ts
@@ -61,6 +61,6 @@ export function buildConvexClientOptions(config: ConvexClientConfig): NextjsOpti
     return options;
   }
 
-  options.adminToken = authToken;
+  (options as NextjsOptions & { adminToken?: string }).adminToken = authToken;
   return options;
 }

--- a/web/src/lib/history/repository.ts
+++ b/web/src/lib/history/repository.ts
@@ -38,7 +38,7 @@ export class ConvexHistoryRepository implements HistoryRepository {
   }
 
   private async query<TArgs extends object, TResult>(
-    reference: FunctionReference<'query', TArgs, TResult>,
+    reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
@@ -49,7 +49,7 @@ export class ConvexHistoryRepository implements HistoryRepository {
   }
 
   private async mutation<TArgs extends object, TResult>(
-    reference: FunctionReference<'mutation', TArgs, TResult>,
+    reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {

--- a/web/src/lib/history/repository.ts
+++ b/web/src/lib/history/repository.ts
@@ -1,3 +1,7 @@
+import type { FunctionReference } from 'convex/server';
+import { fetchMutation, fetchQuery, type NextjsOptions } from 'convex/nextjs';
+import { api } from '../../../convex/_generated/api';
+import { buildConvexClientOptions } from '../convex/client';
 import type { HistoryEntryPayload } from './types';
 
 export interface HistoryRepository {
@@ -11,100 +15,68 @@ interface ConvexHistoryRepositoryOptions {
   baseUrl: string;
   authToken: string;
   authScheme?: string;
-  fetchImpl?: typeof fetch;
 }
-
-interface ConvexResponse<T> {
-  result: T;
-}
-
-const HISTORY_ENDPOINTS = {
-  list: ['history/list'],
-  record: ['history/record'],
-  remove: ['history/remove'],
-  clear: ['history/clear'],
-};
 
 export class ConvexHistoryRepository implements HistoryRepository {
-  private readonly baseUrl: string;
-  private readonly authToken: string;
-  private readonly authScheme: string;
-  private readonly fetchImpl: typeof fetch;
+  private readonly clientOptions: NextjsOptions;
 
   constructor(options: ConvexHistoryRepositoryOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/$/, '');
-    this.authToken = options.authToken;
-    this.authScheme = options.authScheme ?? 'Bearer';
-    this.fetchImpl = options.fetchImpl ?? fetch;
-  }
-
-  private buildUrl(path: string): string[] {
-    const suffixes = [`/api/${path}`, `/${path}`, `/api/http/${path}`, `/http/${path}`];
-    return suffixes.map((suffix) => {
-      try {
-        return new URL(suffix, this.baseUrl).toString();
-      } catch {
-        return `${this.baseUrl}${suffix}`;
-      }
+    this.clientOptions = buildConvexClientOptions({
+      baseUrl: options.baseUrl,
+      authToken: options.authToken,
+      authScheme: options.authScheme,
     });
   }
 
-  private async execute<T>(pathCandidates: string[], body: unknown): Promise<T> {
-    const headers = new Headers({
-      Authorization: `${this.authScheme} ${this.authToken}`,
-      'Content-Type': 'application/json',
-    });
-
-    let lastError: Error | null = null;
-
-    for (const candidate of pathCandidates) {
-      for (const url of this.buildUrl(candidate)) {
-        try {
-          const response = await this.fetchImpl(url, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(body),
-          });
-
-          if (!response.ok) {
-            const errorBody = await response.text().catch(() => '');
-            throw new Error(`Convex history request failed (${response.status}): ${errorBody}`);
-          }
-
-          const payload = (await response.json()) as ConvexResponse<T> | T;
-          if (payload && typeof payload === 'object' && 'result' in payload) {
-            return (payload as ConvexResponse<T>).result;
-          }
-          return payload as T;
-        } catch (error) {
-          lastError = error instanceof Error ? error : new Error('Unknown Convex history error');
-        }
-      }
+  private wrapError(error: unknown): Error {
+    if (error instanceof Error) {
+      const wrapped = new Error(`Convex history request failed: ${error.message}`);
+      (wrapped as Error & { cause?: unknown }).cause = error;
+      return wrapped;
     }
+    return new Error(`Convex history request failed: ${String(error)}`);
+  }
 
-    if (lastError) {
-      throw lastError;
+  private async query<TArgs extends object, TResult>(
+    reference: FunctionReference<'query', TArgs, TResult>,
+    args: TArgs,
+  ): Promise<TResult> {
+    try {
+      return await fetchQuery(reference, args, this.clientOptions);
+    } catch (error) {
+      throw this.wrapError(error);
     }
-    throw new Error('Convex history request failed: no endpoints succeeded');
+  }
+
+  private async mutation<TArgs extends object, TResult>(
+    reference: FunctionReference<'mutation', TArgs, TResult>,
+    args: TArgs,
+  ): Promise<TResult> {
+    try {
+      return await fetchMutation(reference, args, this.clientOptions);
+    } catch (error) {
+      throw this.wrapError(error);
+    }
   }
 
   async list(userId: string, limit?: number): Promise<HistoryEntryPayload[]> {
-    return await this.execute<HistoryEntryPayload[]>(HISTORY_ENDPOINTS.list, {
+    const result = await this.query(api.history.list, {
       userId,
       limit,
     });
+    return result ?? [];
   }
 
   async record(entry: HistoryEntryPayload): Promise<void> {
-    await this.execute(HISTORY_ENDPOINTS.record, { entry });
+    await this.mutation(api.history.record, { entry });
   }
 
   async remove(userId: string, id: string): Promise<void> {
-    await this.execute(HISTORY_ENDPOINTS.remove, { userId, id });
+    await this.mutation(api.history.remove, { userId, id });
   }
 
   async clear(userId: string): Promise<void> {
-    await this.execute(HISTORY_ENDPOINTS.clear, { userId });
+    await this.mutation(api.history.clear, { userId });
   }
 }
 

--- a/web/src/lib/history/repository.ts
+++ b/web/src/lib/history/repository.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference } from 'convex/server';
+import type { DefaultFunctionArgs, FunctionReference } from 'convex/server';
 import { fetchMutation, fetchQuery, type NextjsOptions } from 'convex/nextjs';
 import { api } from '../../../convex/_generated/api';
 import { buildConvexClientOptions } from '../convex/client';
@@ -37,23 +37,31 @@ export class ConvexHistoryRepository implements HistoryRepository {
     return new Error(`Convex history request failed: ${String(error)}`);
   }
 
-  private async query<TArgs extends object, TResult>(
+  private async query<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchQuery(reference, args, this.clientOptions);
+      return (await fetchQuery(
+        reference as FunctionReference<'query', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
   }
 
-  private async mutation<TArgs extends object, TResult>(
+  private async mutation<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchMutation(reference, args, this.clientOptions);
+      return (await fetchMutation(
+        reference as FunctionReference<'mutation', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
@@ -64,7 +72,7 @@ export class ConvexHistoryRepository implements HistoryRepository {
       userId,
       limit,
     });
-    return result ?? [];
+    return (result ?? []) as HistoryEntryPayload[];
   }
 
   async record(entry: HistoryEntryPayload): Promise<void> {

--- a/web/src/lib/pipelines/repository.ts
+++ b/web/src/lib/pipelines/repository.ts
@@ -259,7 +259,7 @@ export class ConvexPipelineRepository implements PipelineRepository {
   }
 
   private async query<TArgs extends object, TResult>(
-    reference: FunctionReference<'query', TArgs, TResult>,
+    reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
@@ -270,7 +270,7 @@ export class ConvexPipelineRepository implements PipelineRepository {
   }
 
   private async mutation<TArgs extends object, TResult>(
-    reference: FunctionReference<'mutation', TArgs, TResult>,
+    reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {

--- a/web/src/lib/pipelines/repository.ts
+++ b/web/src/lib/pipelines/repository.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { dirname } from 'node:path';
-import type { FunctionReference } from 'convex/server';
+import type { DefaultFunctionArgs, FunctionReference } from 'convex/server';
 import { fetchMutation, fetchQuery, type NextjsOptions } from 'convex/nextjs';
 import { api } from '../../../convex/_generated/api';
 import { buildConvexClientOptions } from '../convex/client';
@@ -258,23 +258,31 @@ export class ConvexPipelineRepository implements PipelineRepository {
     return new Error(`Convex pipelines request failed: ${String(error)}`);
   }
 
-  private async query<TArgs extends object, TResult>(
+  private async query<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchQuery(reference, args, this.clientOptions);
+      return (await fetchQuery(
+        reference as FunctionReference<'query', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
   }
 
-  private async mutation<TArgs extends object, TResult>(
+  private async mutation<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchMutation(reference, args, this.clientOptions);
+      return (await fetchMutation(
+        reference as FunctionReference<'mutation', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }

--- a/web/src/lib/provisioning/storage/convexStore.ts
+++ b/web/src/lib/provisioning/storage/convexStore.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference } from 'convex/server';
+import type { DefaultFunctionArgs, FunctionReference } from 'convex/server';
 import { fetchMutation, fetchQuery, type NextjsOptions } from 'convex/nextjs';
 import { api } from '../../../../convex/_generated/api';
 import { buildConvexClientOptions } from '../../convex/client';
@@ -34,30 +34,40 @@ export class ConvexProvisioningStore implements ProvisioningStore {
     return new Error(`Convex provisioning request failed: ${String(error)}`);
   }
 
-  private async query<TArgs extends object, TResult>(
+  private async query<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchQuery(reference, args, this.clientOptions);
+      return (await fetchQuery(
+        reference as FunctionReference<'query', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
   }
 
-  private async mutation<TArgs extends object, TResult>(
+  private async mutation<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchMutation(reference, args, this.clientOptions);
+      return (await fetchMutation(
+        reference as FunctionReference<'mutation', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
   }
 
   async save(record: ProvisionedCredentialRecord): Promise<void> {
-    await this.mutation(api.provisioning.saveCredential, { record });
+    await this.mutation(api.provisioning.saveCredential, {
+      record: { ...record, scopes: [...record.scopes] } as DefaultFunctionArgs,
+    } as DefaultFunctionArgs);
   }
 
   async findActive(userId: string, provider: string): Promise<ProvisionedCredentialRecord | null> {
@@ -65,7 +75,7 @@ export class ConvexProvisioningStore implements ProvisioningStore {
       userId,
       provider,
     });
-    return result.credential;
+    return result.credential as ProvisionedCredentialRecord | null;
   }
 
   async markRevoked(credentialId: string): Promise<void> {
@@ -74,16 +84,16 @@ export class ConvexProvisioningStore implements ProvisioningStore {
 
   async list(): Promise<ProvisionedCredentialRecord[]> {
     const result = await this.query(api.provisioning.listCredentials, {});
-    return result.credentials ?? [];
+    return (result.credentials ?? []) as ProvisionedCredentialRecord[];
   }
 
   async recordUsage(entry: Omit<UsageRecord, 'id'> & { id?: string }): Promise<UsageRecord> {
-    const result = await this.mutation(api.provisioning.recordUsage, { entry });
-    return result.usage;
+    const result = await this.mutation(api.provisioning.recordUsage, { entry } as DefaultFunctionArgs);
+    return result.usage as UsageRecord;
   }
 
   async listUsage(userId: string): Promise<UsageRecord[]> {
     const result = await this.query(api.provisioning.listUsage, { userId });
-    return result.usage ?? [];
+    return (result.usage ?? []) as UsageRecord[];
   }
 }

--- a/web/src/lib/provisioning/storage/convexStore.ts
+++ b/web/src/lib/provisioning/storage/convexStore.ts
@@ -35,7 +35,7 @@ export class ConvexProvisioningStore implements ProvisioningStore {
   }
 
   private async query<TArgs extends object, TResult>(
-    reference: FunctionReference<'query', TArgs, TResult>,
+    reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
@@ -46,7 +46,7 @@ export class ConvexProvisioningStore implements ProvisioningStore {
   }
 
   private async mutation<TArgs extends object, TResult>(
-    reference: FunctionReference<'mutation', TArgs, TResult>,
+    reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {

--- a/web/src/lib/session/storage/convexStore.ts
+++ b/web/src/lib/session/storage/convexStore.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference } from 'convex/server';
+import type { DefaultFunctionArgs, FunctionReference } from 'convex/server';
 import { fetchMutation, type NextjsOptions } from 'convex/nextjs';
 import { api } from '../../../../convex/_generated/api';
 import { buildConvexClientOptions } from '../../convex/client';
@@ -30,12 +30,16 @@ export class ConvexSessionStore implements SessionStore {
     return new Error(`Convex session request failed: ${String(error)}`);
   }
 
-  private async mutation<TArgs extends object, TResult>(
+  private async mutation<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchMutation(reference, args, this.clientOptions);
+      return (await fetchMutation(
+        reference as FunctionReference<'mutation', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }

--- a/web/src/lib/session/storage/convexStore.ts
+++ b/web/src/lib/session/storage/convexStore.ts
@@ -1,73 +1,60 @@
+import type { FunctionReference } from 'convex/server';
+import { fetchMutation, type NextjsOptions } from 'convex/nextjs';
+import { api } from '../../../../convex/_generated/api';
+import { buildConvexClientOptions } from '../../convex/client';
 import type { SessionRecord, SessionStore } from '../types';
 
 interface ConvexSessionStoreOptions {
   baseUrl: string;
   authToken: string;
   authScheme?: string;
-  fetchImpl?: typeof fetch;
-}
-
-interface ConvexResponse<T> {
-  result: T;
-}
-
-function buildHeaders(token: string, scheme: string): HeadersInit {
-  return {
-    Authorization: `${scheme} ${token}`,
-    'Content-Type': 'application/json',
-  };
 }
 
 export class ConvexSessionStore implements SessionStore {
-  private readonly baseUrl: string;
-  private readonly authToken: string;
-  private readonly authScheme: string;
-  private readonly fetchImpl: typeof fetch;
+  private readonly clientOptions: NextjsOptions;
 
   constructor(options: ConvexSessionStoreOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/$/, '');
-    this.authToken = options.authToken;
-    this.authScheme = options.authScheme ?? 'Bearer';
-    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.clientOptions = buildConvexClientOptions({
+      baseUrl: options.baseUrl,
+      authToken: options.authToken,
+      authScheme: options.authScheme,
+    });
   }
 
-  private async request<T>(path: string, body?: unknown): Promise<T> {
-    const response = await this.fetchImpl(`${this.baseUrl}/api/session/${path}`, {
-      method: 'POST',
-      headers: buildHeaders(this.authToken, this.authScheme),
-      body: body ? JSON.stringify(body) : undefined,
-    });
-
-    if (!response.ok) {
-      const errorBody = await response.text().catch(() => '');
-      throw new Error(`Convex session request failed (${response.status}): ${errorBody}`);
+  private wrapError(error: unknown): Error {
+    if (error instanceof Error) {
+      const wrapped = new Error(`Convex session request failed: ${error.message}`);
+      (wrapped as Error & { cause?: unknown }).cause = error;
+      return wrapped;
     }
+    return new Error(`Convex session request failed: ${String(error)}`);
+  }
 
-    if (response.status === 204) {
-      return undefined as T;
+  private async mutation<TArgs extends object, TResult>(
+    reference: FunctionReference<'mutation', TArgs, TResult>,
+    args: TArgs,
+  ): Promise<TResult> {
+    try {
+      return await fetchMutation(reference, args, this.clientOptions);
+    } catch (error) {
+      throw this.wrapError(error);
     }
-
-    const payload = (await response.json().catch(() => ({}))) as ConvexResponse<T> | T;
-    if (payload && typeof payload === 'object' && 'result' in payload) {
-      return (payload as ConvexResponse<T>).result;
-    }
-    return payload as T;
   }
 
   async save(record: SessionRecord): Promise<void> {
-    await this.request('save', { record });
+    await this.mutation(api.session.save, { record });
   }
 
   async find(id: string): Promise<SessionRecord | null> {
-    const result = await this.request<{ session: SessionRecord | null }>('get', { sessionId: id });
-    return result.session;
+    const result = await this.mutation(api.session.get, { sessionId: id });
+    return result.session ?? null;
   }
 
   async delete(id: string): Promise<void> {
-    await this.request('delete', { sessionId: id });
+    await this.mutation(api.session.deleteSession, { sessionId: id });
   }
 
   async prune(now: number): Promise<void> {
-    await this.request('prune', { now });
+    await this.mutation(api.session.prune, { now });
   }
 }

--- a/web/src/lib/session/storage/convexStore.ts
+++ b/web/src/lib/session/storage/convexStore.ts
@@ -31,7 +31,7 @@ export class ConvexSessionStore implements SessionStore {
   }
 
   private async mutation<TArgs extends object, TResult>(
-    reference: FunctionReference<'mutation', TArgs, TResult>,
+    reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {

--- a/web/src/lib/translations/repository.ts
+++ b/web/src/lib/translations/repository.ts
@@ -59,7 +59,7 @@ export class ConvexTranslationRepository implements TranslationRepository {
   }
 
   private async query<TArgs extends object, TResult>(
-    reference: FunctionReference<'query', TArgs, TResult>,
+    reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
@@ -70,7 +70,7 @@ export class ConvexTranslationRepository implements TranslationRepository {
   }
 
   private async mutation<TArgs extends object, TResult>(
-    reference: FunctionReference<'mutation', TArgs, TResult>,
+    reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {

--- a/web/src/lib/translations/repository.ts
+++ b/web/src/lib/translations/repository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { FunctionReference } from 'convex/server';
+import type { DefaultFunctionArgs, FunctionReference } from 'convex/server';
 import { fetchMutation, fetchQuery, type NextjsOptions } from 'convex/nextjs';
 import { api } from '../../../convex/_generated/api';
 import { buildConvexClientOptions } from '../convex/client';
@@ -58,23 +58,31 @@ export class ConvexTranslationRepository implements TranslationRepository {
     return new Error(`Convex translations request failed: ${String(error)}`);
   }
 
-  private async query<TArgs extends object, TResult>(
+  private async query<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'query', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchQuery(reference, args, this.clientOptions);
+      return (await fetchQuery(
+        reference as FunctionReference<'query', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }
   }
 
-  private async mutation<TArgs extends object, TResult>(
+  private async mutation<TArgs extends DefaultFunctionArgs, TResult>(
     reference: FunctionReference<'mutation', any, TArgs, TResult>,
     args: TArgs,
   ): Promise<TResult> {
     try {
-      return await fetchMutation(reference, args, this.clientOptions);
+      return (await fetchMutation(
+        reference as FunctionReference<'mutation', any, DefaultFunctionArgs, TResult>,
+        args as DefaultFunctionArgs,
+        this.clientOptions,
+      )) as TResult;
     } catch (error) {
       throw this.wrapError(error);
     }

--- a/web/src/tests/unit/accountRepositoryFallback.test.ts
+++ b/web/src/tests/unit/accountRepositoryFallback.test.ts
@@ -4,39 +4,41 @@ import {
   getAccountRepositoryKind,
   resetAccountRepositoryForTesting,
 } from '@/app/api/account/context';
+import { fetchMutation } from 'convex/nextjs';
+
+vi.mock('convex/nextjs', () => ({
+  fetchMutation: vi.fn(),
+  fetchQuery: vi.fn(),
+}));
 
 describe('account repository context', () => {
   beforeEach(() => {
     resetAccountRepositoryForTesting();
-    process.env.CONVEX_URL = 'https://example.convex.site';
+    process.env.CONVEX_URL = 'https://example.convex.cloud';
     process.env.CONVEX_DEPLOYMENT_KEY = 'test-token';
+    (fetchMutation as unknown as vi.Mock).mockReset();
   });
 
   afterEach(() => {
     resetAccountRepositoryForTesting();
     delete process.env.CONVEX_URL;
     delete process.env.CONVEX_DEPLOYMENT_KEY;
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   it('falls back to the in-memory repository when Convex responds with 404', async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: false,
-      status: 404,
-      text: async () => 'No matching routes found',
-    }));
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMutationMock = fetchMutation as unknown as vi.Mock;
+    fetchMutationMock.mockRejectedValue(new Error('Convex account request failed: No matching routes found'));
 
     const repository = getAccountRepository();
     const account = await repository.getOrCreate('user-1');
 
     expect(account.userId).toBe('user-1');
     expect(getAccountRepositoryKind()).toBe('in-memory');
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMutationMock).toHaveBeenCalledTimes(1);
 
-    fetchMock.mockClear();
+    fetchMutationMock.mockClear();
     await repository.getOrCreate('user-1');
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMutationMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/tests/unit/convexClientOptions.test.ts
+++ b/web/src/tests/unit/convexClientOptions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildConvexClientOptions } from '@/lib/convex/client';
+
+describe('buildConvexClientOptions', () => {
+  it('returns admin token options by default', () => {
+    const options = buildConvexClientOptions({
+      baseUrl: 'https://example.convex.cloud/',
+      authToken: 'admin-token',
+    });
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        url: 'https://example.convex.cloud',
+        adminToken: 'admin-token',
+        skipConvexDeploymentUrlCheck: true,
+      }),
+    );
+  });
+
+  it('honours bearer auth scheme for user tokens', () => {
+    const options = buildConvexClientOptions({
+      baseUrl: 'https://example.convex.cloud',
+      authToken: 'user-token',
+      authScheme: 'Bearer',
+    });
+
+    expect(options).toMatchObject({
+      url: 'https://example.convex.cloud',
+      token: 'user-token',
+      skipConvexDeploymentUrlCheck: true,
+    });
+    expect(options).not.toHaveProperty('adminToken');
+  });
+
+  it('falls back to admin token for unknown schemes', () => {
+    const options = buildConvexClientOptions({
+      baseUrl: 'https://example.convex.cloud',
+      authToken: 'mystery-token',
+      authScheme: 'Unknown',
+    });
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        adminToken: 'mystery-token',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add \ helper to centralise Convex HTTP configuration
- switch all Convex-backed repositories and auth sync route to \/\
- refresh unit tests and mocks for the new helper and fallback handling

## Testing
- npm test