### PR TITLE
fix: canonicalise Convex deployment URLs

### DIFF
--- a/web/src/lib/convex/client.ts
+++ b/web/src/lib/convex/client.ts
@@ -6,8 +6,24 @@ export interface ConvexClientConfig {
   authScheme?: string;
 }
 
+function canonicaliseDeploymentUrl(url: string): string {
+  const trimmed = url.trim();
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.hostname.endsWith('.convex.site')) {
+      parsed.hostname = parsed.hostname.replace(/\.convex\.site$/, '.convex.cloud');
+    }
+    return parsed.toString();
+  } catch {
+    if (trimmed.endsWith('.convex.site')) {
+      return trimmed.replace(/\.convex\.site(?=[/?#]|$)/, '.convex.cloud');
+    }
+    return trimmed;
+  }
+}
+
 function normaliseBaseUrl(url: string): string {
-  return url.trim().replace(/\/+$/, '');
+  return canonicaliseDeploymentUrl(url).replace(/\/+$/, '');
 }
 
 function resolveAuthKind(scheme?: string): 'admin' | 'user' | null {

--- a/web/src/tests/unit/convexClientOptions.test.ts
+++ b/web/src/tests/unit/convexClientOptions.test.ts
@@ -45,4 +45,13 @@ describe('buildConvexClientOptions', () => {
       }),
     );
   });
+
+  it('canonicalises convex site domains to convex cloud', () => {
+    const options = buildConvexClientOptions({
+      baseUrl: 'https://cheery-chihuahua-877.convex.site',
+      authToken: 'token',
+    });
+
+    expect(options.url).toBe('https://cheery-chihuahua-877.convex.cloud');
+  });
 });


### PR DESCRIPTION
## Summary
- rewrite any *.convex.site deployment URL to *.convex.cloud before building Convex client options
- keep admin token wiring intact while still skipping Convex URL validation
- extend unit coverage for the new canonicalisation helper

## Testing
- npm test
- npm run build