### PR TITLE
Fix Convex session query semantics and pipeline lookups

### DIFF
--- a/web/convex/http.ts
+++ b/web/convex/http.ts
@@ -345,7 +345,7 @@ router.route({
   handler: httpAction(async (ctx, request) => {
     requireAdmin(request);
     const body = (await request.json()) as any;
-    const result = await executeWithLogging('/session/get', () => ctx.runMutation(api.session.get, body));
+    const result = await executeWithLogging('/session/get', () => ctx.runQuery(api.session.get, body));
     return json(result);
   }),
 });

--- a/web/convex/pipelines.ts
+++ b/web/convex/pipelines.ts
@@ -33,14 +33,14 @@ function mapPipeline(doc: PipelineDoc) {
 async function loadPipelineById(ctx: MutationCtx | QueryCtx, id: string): Promise<PipelineDoc | null> {
   return await ctx.db
     .query('pipelines')
-    .filter((q) => q.eq(q.field('id'), id))
+    .withIndex('by_id', (q) => q.eq('id', id))
     .first();
 }
 
 async function loadPipelineBySecret(ctx: MutationCtx | QueryCtx, secret: string): Promise<PipelineDoc | null> {
   return await ctx.db
     .query('pipelines')
-    .filter((q) => q.eq(q.field('webhookSecret'), secret))
+    .withIndex('by_webhook_secret', (q) => q.eq('webhookSecret', secret))
     .first();
 }
 

--- a/web/convex/session.ts
+++ b/web/convex/session.ts
@@ -1,4 +1,4 @@
-import { mutation } from './_generated/server';
+import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
 
 export const save = mutation({
@@ -25,7 +25,7 @@ export const save = mutation({
   },
 });
 
-export const get = mutation({
+export const get = query({
   args: { sessionId: v.string() },
   handler: async (ctx, { sessionId }) => {
     const session = await ctx.db


### PR DESCRIPTION
## Summary
- convert the Convex `session.get` handler into a query and update both the HTTP router and Next.js session store to call it via `runQuery`/`fetchQuery`
- add a shared query helper to `ConvexSessionStore` so reads use the correct client API
- switch pipeline lookups to use indexed queries for ids and webhook secrets instead of full table scans

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68eae02f87ec8322bceb3ad45269a9d2