### PR TITLE
Fix Convex pipeline lookup typing regression

### DIFF
--- a/web/convex/http.ts
+++ b/web/convex/http.ts
@@ -345,7 +345,7 @@ router.route({
   handler: httpAction(async (ctx, request) => {
     requireAdmin(request);
     const body = (await request.json()) as any;
-    const result = await executeWithLogging('/session/get', () => ctx.runMutation(api.session.get, body));
+    const result = await executeWithLogging('/session/get', () => ctx.runQuery(api.session.get, body));
     return json(result);
   }),
 });

--- a/web/convex/session.ts
+++ b/web/convex/session.ts
@@ -1,4 +1,4 @@
-import { mutation } from './_generated/server';
+import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
 
 export const save = mutation({
@@ -25,7 +25,7 @@ export const save = mutation({
   },
 });
 
-export const get = mutation({
+export const get = query({
   args: { sessionId: v.string() },
   handler: async (ctx, { sessionId }) => {
     const session = await ctx.db

--- a/web/src/tests/unit/convexPipelines.test.ts
+++ b/web/src/tests/unit/convexPipelines.test.ts
@@ -11,14 +11,17 @@ class FakeQueryBuilder {
 
   constructor(private readonly source: FakeDb) {}
 
-  withIndex(_name: string, apply: (builder: { eq: (field: string, value: unknown) => unknown }) => void) {
+  withIndex(
+    _name: string,
+    apply?: (builder: { eq: (field: string, value: unknown) => unknown }) => void,
+  ) {
     const builder = {
       eq: (field: string, value: unknown) => {
         this.eqConditions.push({ field, value });
         return builder;
       },
     };
-    apply(builder);
+    apply?.(builder);
     return this;
   }
 


### PR DESCRIPTION
## Summary
- reuse the Convex DatabaseReader in pipeline lookup helpers so ctx.db works in both queries and mutations
- keep index usage while adding filter-based predicates that satisfy TypeScript
- relax the convex pipelines test double so withIndex can be invoked without an index-range callback

## Testing
- CI=1 npm run build
- npx vitest run src/tests/unit/convexPipelines.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68eae02f87ec8322bceb3ad45269a9d2