### PR TITLE
fix: align Convex schema and session store

### DIFF
--- a/Docs/pipeline-convex-design.md
+++ b/Docs/pipeline-convex-design.md
@@ -24,7 +24,7 @@
 | `lastRunAt` | `optional string` | Last completed run. |
 
 Indexes:
-- `by_id` (`id`)
+- `by_pipeline_id` (`id`)
 - `by_name` (`name`)
 - `by_webhook_secret` (`webhookSecret`)
 

--- a/web/convex/README.md
+++ b/web/convex/README.md
@@ -51,7 +51,7 @@ export const markCredentialRevoked = mutation({
   handler: async (ctx, { credentialId }) => {
     const credential = await ctx.db
       .query('provisioning_credentials')
-      .withIndex('by_id', (q) => q.eq('id', credentialId))
+      .withIndex('by_credential_id', (q) => q.eq('id', credentialId))
       .first();
     if (!credential) return { result: false };
     await ctx.db.patch(credential._id, { status: 'revoked' });
@@ -208,7 +208,7 @@ export const save = mutation({
   handler: async (ctx, { record }) => {
     const existing = await ctx.db
       .query('sessions')
-      .withIndex('by_id', (q) => q.eq('id', record.id))
+      .withIndex('by_session_id', (q) => q.eq('id', record.id))
       .first();
     if (existing) {
       await ctx.db.patch(existing._id, record);
@@ -224,7 +224,7 @@ export const get = mutation({
   handler: async (ctx, { sessionId }) => {
     const session = await ctx.db
       .query('sessions')
-      .withIndex('by_id', (q) => q.eq('id', sessionId))
+      .withIndex('by_session_id', (q) => q.eq('id', sessionId))
       .first();
     return { session: session ?? null };
   },
@@ -235,7 +235,7 @@ export const deleteSession = mutation({
   handler: async (ctx, { sessionId }) => {
     const session = await ctx.db
       .query('sessions')
-      .withIndex('by_id', (q) => q.eq('id', sessionId))
+      .withIndex('by_session_id', (q) => q.eq('id', sessionId))
       .first();
     if (session) {
       await ctx.db.delete(session._id);

--- a/web/convex/pipelines.ts
+++ b/web/convex/pipelines.ts
@@ -33,7 +33,7 @@ function mapPipeline(doc: PipelineDoc) {
 async function loadPipelineById(db: DatabaseReader, id: string): Promise<PipelineDoc | null> {
   return await db
     .query('pipelines')
-    .withIndex('by_id')
+    .withIndex('by_pipeline_id')
     .filter((q) => q.eq(q.field('id'), id))
     .first();
 }

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -103,7 +103,7 @@ export default defineSchema({
     updatedAt: v.string(),
     lastRunAt: v.optional(v.string()),
   })
-    .index('by_id', ['id'])
+    .index('by_pipeline_id', ['id'])
     .index('by_name', ['name'])
     .index('by_webhook_secret', ['webhookSecret']),
 });


### PR DESCRIPTION
## Summary
- rename the Convex pipelines index to bypass the reserved name validation failure
- sanitize Convex session responses before persisting to avoid metadata validation errors
- update documentation and test coverage so shared snippets stay accurate

## Affected Modules
- Docs/pipeline-convex-design.md
- web/convex/schema.ts
- web/convex/pipelines.ts
- web/convex/session.ts
- web/convex/README.md
- web/src/lib/session/storage/convexStore.ts
- web/src/tests/unit/sessionRegistry.test.ts

## Testing
- npx vitest run sessionRegistry.test.ts