### PR TITLE
fix: align Convex schema and session store

### DIFF
--- a/web/convex/README.md
+++ b/web/convex/README.md
@@ -194,8 +194,17 @@ For full details see the Convex docs: https://docs.convex.dev/functions/http-act
 Persist the encrypted session secrets that power the browser vault so stateless deploys (e.g. Vercel) can decrypt API keys between requests.
 
 ```ts
-import { mutation } from './_generated/server';
+import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
+import type { Doc } from './_generated/dataModel';
+
+function mapSession(doc: Doc<'sessions'>) {
+  return {
+    id: doc.id,
+    secret: doc.secret,
+    expiresAt: doc.expiresAt,
+  };
+}
 
 export const save = mutation({
   args: {
@@ -219,14 +228,14 @@ export const save = mutation({
   },
 });
 
-export const get = mutation({
+export const get = query({
   args: { sessionId: v.string() },
   handler: async (ctx, { sessionId }) => {
     const session = await ctx.db
       .query('sessions')
       .withIndex('by_session_id', (q) => q.eq('id', sessionId))
       .first();
-    return { session: session ?? null };
+    return { session: session ? mapSession(session) : null };
   },
 });
 

--- a/web/convex/session.ts
+++ b/web/convex/session.ts
@@ -1,5 +1,20 @@
 import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
+import type { Doc } from './_generated/dataModel';
+
+interface SessionRecord {
+  id: string;
+  secret: string;
+  expiresAt: number;
+}
+
+function mapSession(doc: Doc<'sessions'>): SessionRecord {
+  return {
+    id: doc.id,
+    secret: doc.secret,
+    expiresAt: doc.expiresAt,
+  };
+}
 
 export const save = mutation({
   args: {
@@ -33,7 +48,7 @@ export const get = query({
       .withIndex('by_session_id', (q) => q.eq('id', sessionId))
       .first();
 
-    return { session: session ?? null };
+    return { session: session ? mapSession(session) : null };
   },
 });
 

--- a/web/src/lib/session/storage/convexStore.ts
+++ b/web/src/lib/session/storage/convexStore.ts
@@ -66,7 +66,11 @@ export class ConvexSessionStore implements SessionStore {
 
   async find(id: string): Promise<SessionRecord | null> {
     const result = await this.query(api.session.get, { sessionId: id });
-    return result.session ?? null;
+    if (!result.session) {
+      return null;
+    }
+    const { id: sessionId, secret, expiresAt } = result.session;
+    return { id: sessionId, secret, expiresAt };
   }
 
   async delete(id: string): Promise<void> {

--- a/web/src/tests/unit/sessionRegistry.test.ts
+++ b/web/src/tests/unit/sessionRegistry.test.ts
@@ -6,7 +6,7 @@ import {
   clearSession,
 } from '@/app/api/_lib/sessionRegistry';
 import { getSessionStoreKind, resetSessionStoreForTesting } from '@/lib/session';
-import { fetchMutation } from 'convex/nextjs';
+import { fetchMutation, fetchQuery } from 'convex/nextjs';
 
 vi.mock('convex/nextjs', () => ({
   fetchMutation: vi.fn(),
@@ -21,6 +21,7 @@ describe('sessionRegistry', () => {
     process.env.CONVEX_URL = 'https://example.convex.cloud';
     process.env.CONVEX_DEPLOYMENT_KEY = 'test-token';
     (fetchMutation as unknown as vi.Mock).mockReset();
+    (fetchQuery as unknown as vi.Mock).mockReset();
   });
 
   afterEach(() => {
@@ -43,5 +44,35 @@ describe('sessionRegistry', () => {
     expect((secret as Uint8Array).length).toBeGreaterThan(0);
 
     await clearSession('session-1');
+  });
+  it('strips Convex metadata when extending a session expiry', async () => {
+    const fetchMutationMock = fetchMutation as unknown as vi.Mock;
+    const fetchQueryMock = fetchQuery as unknown as vi.Mock;
+
+    const expiresSoon = Date.now() + 1_000;
+    fetchQueryMock.mockResolvedValue({
+      session: {
+        id: 'session-1',
+        secret: BASE64_SECRET,
+        expiresAt: expiresSoon,
+        _id: 'convex-doc-id',
+        _creationTime: Date.now(),
+      },
+    });
+
+    fetchMutationMock.mockResolvedValue({ result: true });
+
+    const secret = await resolveSessionSecret('session-1');
+    expect(secret).not.toBeNull();
+
+    expect(fetchMutationMock).toHaveBeenCalledTimes(1);
+    const [, args] = fetchMutationMock.mock.calls[0];
+    expect(args).toHaveProperty('record');
+    expect(args.record).toMatchObject({
+      id: 'session-1',
+      secret: BASE64_SECRET,
+    });
+    expect(typeof args.record.expiresAt).toBe('number');
+    expect(Object.keys(args.record)).toEqual(['id', 'secret', 'expiresAt']);
   });
 });


### PR DESCRIPTION
## Summary
- rename the Convex pipelines index to bypass the reserved name validation failure
- sanitize Convex session responses before persisting to avoid metadata validation errors
- update documentation and tests so shared snippets stay accurate

## Affected Modules
- Docs/pipeline-convex-design.md
- web/convex/schema.ts
- web/convex/pipelines.ts
- web/convex/session.ts
- web/convex/README.md
- web/src/lib/session/storage/convexStore.ts
- web/src/tests/unit/sessionRegistry.test.ts

## Testing
- npx vitest run sessionRegistry.test.ts