### PR TITLE
fix: forward auth headers to translations

### DIFF
--- a/web/src/lib/translations/client.ts
+++ b/web/src/lib/translations/client.ts
@@ -33,10 +33,17 @@ function buildUrl(documentId: string, params?: { cursor?: string; limit?: number
   return query ? `${BASE_URL}?${query}` : BASE_URL;
 }
 
-async function postAction<T>(payload: Record<string, unknown>): Promise<T> {
+interface PostActionOptions {
+  headers?: Record<string, string>;
+}
+
+async function postAction<T>(payload: Record<string, unknown>, options?: PostActionOptions): Promise<T> {
   const response = await fetch(BASE_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options?.headers ?? {}),
+    },
     body: JSON.stringify(payload),
   });
   return (await ensureOk(response).json()) as T;
@@ -60,12 +67,16 @@ export async function fetchTranslations(
 export async function createTranslation(
   documentId: string,
   payload: TranslateTextRequest,
+  options?: PostActionOptions,
 ): Promise<TranslateResponse> {
-  return await postAction<TranslateResponse>({
-    action: 'translate',
-    documentId,
-    payload,
-  });
+  return await postAction<TranslateResponse>(
+    {
+      action: 'translate',
+      documentId,
+      payload,
+    },
+    options,
+  );
 }
 
 export async function promoteTranslation(


### PR DESCRIPTION
## Summary
- add optional headers support to the translations client post helper
- request provider credentials before creating translations via the store
- cover the auth header path in the translation store unit tests

## Testing
- npm run test -- translationsStore