### PR TITLE
feat: make studio panels draggable

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.49.0",
+        "@tailwindcss/postcss": "^4.1.15",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -48,6 +49,19 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.0.5",
@@ -305,6 +319,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -351,6 +366,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1500,12 +1516,55 @@
         }
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.40.0",
@@ -1761,6 +1820,7 @@
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -2218,12 +2278,284 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.15.tgz",
+      "integrity": "sha512-HF4+7QxATZWY3Jr8OlZrBSXmwT3Watj0OogeDvdUY/ByXJHQ+LBtqA2brDb3sBxYslIFx6UP94BJ4X6a4L9Bmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.0",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.19",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.15"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.15.tgz",
+      "integrity": "sha512-krhX+UOOgnsUuks2SR7hFafXmLQrKxB4YyRTERuCE59JlYL+FawgaAlSkOYmDRJdf1Q+IFNDMl9iRnBW7QBDfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.15",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.15",
+        "@tailwindcss/oxide-darwin-x64": "4.1.15",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.15",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.15",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.15",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.15",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.15",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.15",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.15",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.15",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.15"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.15.tgz",
+      "integrity": "sha512-TkUkUgAw8At4cBjCeVCRMc/guVLKOU1D+sBPrHt5uVcGhlbVKxrCaCW9OKUIBv1oWkjh4GbunD/u/Mf0ql6kEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.15.tgz",
+      "integrity": "sha512-xt5XEJpn2piMSfvd1UFN6jrWXyaKCwikP4Pidcf+yfHTSzSpYhG3dcMktjNkQO3JiLCp+0bG0HoWGvz97K162w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.15.tgz",
+      "integrity": "sha512-TnWaxP6Bx2CojZEXAV2M01Yl13nYPpp0EtGpUrY+LMciKfIXiLL2r/SiSRpagE5Fp2gX+rflp/Os1VJDAyqymg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.15.tgz",
+      "integrity": "sha512-quISQDWqiB6Cqhjc3iWptXVZHNVENsWoI77L1qgGEHNIdLDLFnw3/AfY7DidAiiCIkGX/MjIdB3bbBZR/G2aJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.15.tgz",
+      "integrity": "sha512-ObG76+vPlab65xzVUQbExmDU9FIeYLQ5k2LrQdR2Ud6hboR+ZobXpDoKEYXf/uOezOfIYmy2Ta3w0ejkTg9yxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.15.tgz",
+      "integrity": "sha512-4WbBacRmk43pkb8/xts3wnOZMDKsPFyEH/oisCm2q3aLZND25ufvJKcDUpAu0cS+CBOL05dYa8D4U5OWECuH/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.15.tgz",
+      "integrity": "sha512-AbvmEiteEj1nf42nE8skdHv73NoR+EwXVSgPY6l39X12Ex8pzOwwfi3Kc8GAmjsnsaDEbk+aj9NyL3UeyHcTLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.15.tgz",
+      "integrity": "sha512-+rzMVlvVgrXtFiS+ES78yWgKqpThgV19ISKD58Ck+YO5pO5KjyxLt7AWKsWMbY0R9yBDC82w6QVGz837AKQcHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.15.tgz",
+      "integrity": "sha512-fPdEy7a8eQN9qOIK3Em9D3TO1z41JScJn8yxl/76mp4sAXFDfV4YXxsiptJcOwy6bGR+70ZSwFIZhTXzQeqwQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.15.tgz",
+      "integrity": "sha512-sJ4yd6iXXdlgIMfIBXuVGp/NvmviEoMVWMOAGxtxhzLPp9LOj5k0pMEMZdjeMCl4C6Up+RM8T3Zgk+BMQ0bGcQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.0.7",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.15.tgz",
+      "integrity": "sha512-sJGE5faXnNQ1iXeqmRin7Ds/ru2fgCiaQZQQz3ZGIDtvbkeV85rAZ0QJFMDg0FrqsffZG96H1U9AQlNBRLsHVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.15.tgz",
+      "integrity": "sha512-NLeHE7jUV6HcFKS504bpOohyi01zPXi2PXmjFfkzTph8xRxDdxkRsXm/xDO5uV5K3brrE1cCwbUYmFUSHR3u1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.15.tgz",
+      "integrity": "sha512-IZh8IT76KujRz6d15wZw4eoeViT4TqmzVWNNfpuNCTKiaZUwgr5vtPqO4HjuYDyx3MgGR5qgPt1HMzTeLJyA3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.15",
+        "@tailwindcss/oxide": "4.1.15",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.15"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2369,6 +2701,7 @@
       "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -2379,6 +2712,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2389,6 +2723,7 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2446,6 +2781,7 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3078,6 +3414,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3939,8 +4276,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3986,6 +4323,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -4253,6 +4604,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4426,6 +4778,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5066,6 +5419,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -5766,15 +6126,14 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-cookie": {
@@ -5812,6 +6171,7 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -5938,6 +6298,268 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -6101,6 +6723,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -6195,6 +6818,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.6.tgz",
       "integrity": "sha512-zTxsnI3LQo3c9HSdSf91O1jMNsEzIXDShXd4wVdg9y5shwLqBXi4ZtUUJyB86KGVSJLZx0PFONvO54aheGX8QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.6",
         "@swc/helpers": "0.5.15",
@@ -6626,6 +7250,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7596,11 +8221,25 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
-      "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.15.tgz",
+      "integrity": "sha512-k2WLnWkYFkdpRv+Oby3EBXIyQC8/s1HOFMBUViwtAh6Z5uAozeUSMQlIsn/c6Q2iJzqG6aJT3wdPaRNj70iYxQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7657,6 +8296,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7895,6 +8535,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7999,6 +8640,7 @@
       "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8130,6 +8772,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",
+    "@tailwindcss/postcss": "^4.1.15",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/web/postcss.config.mjs
+++ b/web/postcss.config.mjs
@@ -1,8 +1,8 @@
+import tailwindcss from '@tailwindcss/postcss';
+
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: {
-    tailwindcss: {},
-  },
+  plugins: [tailwindcss()],
 };
 
 export default config;

--- a/web/src/components/shared/panels/InteractivePanel.tsx
+++ b/web/src/components/shared/panels/InteractivePanel.tsx
@@ -1,0 +1,193 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type DragEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react';
+import type { PanelId } from './usePanelLayout';
+
+export const PANEL_DRAG_DATA_TYPE = 'application/x-transit-panel';
+
+interface InteractivePanelProps {
+  id: PanelId;
+  title: string;
+  description?: string;
+  htmlId?: string;
+  className?: string;
+  bodyClassName?: string;
+  collapsed: boolean;
+  height?: number;
+  allowResize?: boolean;
+  allowCollapse?: boolean;
+  headerAccessory?: ReactNode;
+  headerMode?: 'standard' | 'minimal';
+  surfaceVariant?: 'default' | 'bare';
+  children: ReactNode;
+  onToggleCollapse: () => void;
+  onResize: (height?: number) => void;
+  onDragStart: (panelId: PanelId, event: DragEvent<HTMLButtonElement>) => void;
+  onDragEnd: () => void;
+  isDragging?: boolean;
+}
+
+export function InteractivePanel({
+  id,
+  title,
+  description,
+  htmlId,
+  className,
+  bodyClassName,
+  collapsed,
+  height,
+  allowResize = true,
+  allowCollapse = true,
+  headerAccessory,
+  headerMode = 'standard',
+  surfaceVariant = 'default',
+  children,
+  onToggleCollapse,
+  onResize,
+  onDragStart,
+  onDragEnd,
+  isDragging = false,
+}: InteractivePanelProps) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const combinedClassName = useMemo(() => {
+    const baseSurfaceClasses =
+      surfaceVariant === 'default'
+        ? 'relative rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60 transition'
+        : 'relative transition';
+    const classes = [
+      baseSurfaceClasses,
+      'focus-within:ring-2 focus-within:ring-accent-300/60',
+      isDragging ? 'ring-2 ring-accent-400 shadow-accent-300/60' : '',
+      className ?? '',
+    ];
+    return classes.filter(Boolean).join(' ');
+  }, [className, isDragging, surfaceVariant]);
+
+  const handleResizePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!allowResize || collapsed) {
+        return;
+      }
+      event.preventDefault();
+      const startY = event.clientY;
+      const startHeight = height ?? contentRef.current?.offsetHeight ?? 0;
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        const nextHeight = Math.max(160, startHeight + (moveEvent.clientY - startY));
+        onResize(nextHeight);
+      };
+      const onPointerUp = () => {
+        window.removeEventListener('pointermove', onPointerMove);
+        window.removeEventListener('pointerup', onPointerUp);
+      };
+      window.addEventListener('pointermove', onPointerMove);
+      window.addEventListener('pointerup', onPointerUp);
+    },
+    [allowResize, collapsed, height, onResize],
+  );
+
+  const handleResetSize = useCallback(() => {
+    onResize(undefined);
+  }, [onResize]);
+
+  const contentStyle = useMemo<CSSProperties>(() => {
+    if (collapsed) {
+      return { display: 'none' };
+    }
+    if (typeof height === 'number' && Number.isFinite(height)) {
+      return { height, overflowY: 'auto' };
+    }
+    return {};
+  }, [collapsed, height]);
+
+  const dragHandle = (
+    <button
+      type="button"
+      className="flex h-8 w-8 items-center justify-center rounded-full border border-dashed border-charcoal-300 text-sm font-semibold uppercase tracking-[0.15em] text-charcoal-500 transition hover:border-accent-400 hover:text-accent-600"
+      draggable
+      aria-label={`Move ${title}`}
+      onDragStart={(event) => {
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData(PANEL_DRAG_DATA_TYPE, id);
+        event.dataTransfer.setData('text/plain', id);
+        onDragStart(id, event);
+      }}
+      onDragEnd={onDragEnd}
+    >
+      ::
+    </button>
+  );
+
+  const controlButtons = (
+    <>
+      {allowResize && !collapsed ? (
+        <button
+          type="button"
+          className="rounded-full border border-charcoal-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-600 transition hover:bg-charcoal-100/70"
+          onClick={handleResetSize}
+        >
+          Reset
+        </button>
+      ) : null}
+      {allowCollapse ? (
+        <button
+          type="button"
+          className="rounded-full border border-charcoal-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-900 transition hover:bg-charcoal-900 hover:text-cream-50"
+          onClick={onToggleCollapse}
+          aria-expanded={!collapsed}
+          aria-controls={`${id}-panel-content`}
+        >
+          {collapsed ? 'Expand' : 'Collapse'}
+        </button>
+      ) : null}
+    </>
+  );
+
+  const bodyClass = useMemo(() => {
+    const defaults = headerMode === 'standard' ? 'flex flex-col gap-4' : '';
+    return [defaults, bodyClassName ?? ''].filter(Boolean).join(' ');
+  }, [bodyClassName, headerMode]);
+
+  return (
+    <section className={combinedClassName} data-panel-id={id} aria-label={title} id={htmlId}>
+      {headerMode === 'standard' ? (
+        <header className="mb-3 flex flex-wrap items-center gap-3">
+          {dragHandle}
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <h3 className="text-sm font-semibold text-charcoal-900">{title}</h3>
+            {description ? <p className="text-xs text-charcoal-500">{description}</p> : null}
+          </div>
+          {headerAccessory}
+          <div className="ml-auto flex items-center gap-2">{controlButtons}</div>
+        </header>
+      ) : (
+        <div className="pointer-events-none absolute -right-3 -top-3 z-10 flex items-center gap-2">
+          <div className="pointer-events-auto">{dragHandle}</div>
+          <div className="pointer-events-auto flex items-center gap-2">{controlButtons}</div>
+        </div>
+      )}
+      <div
+        id={`${id}-panel-content`}
+        ref={contentRef}
+        className={bodyClass}
+        style={contentStyle}
+      >
+        {children}
+      </div>
+      {allowResize && !collapsed ? (
+        <div
+          className="mt-3 h-3 w-full cursor-row-resize rounded-full border border-dashed border-charcoal-200 bg-transparent transition hover:border-accent-400"
+          onPointerDown={handleResizePointerDown}
+          role="presentation"
+          aria-hidden="true"
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/web/src/components/shared/panels/usePanelLayout.ts
+++ b/web/src/components/shared/panels/usePanelLayout.ts
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type PanelId = string;
+export type ColumnId = string;
+
+export interface PanelLayoutState {
+  columns: Record<ColumnId, PanelId[]>;
+  collapsed: Record<PanelId, boolean | undefined>;
+  heights: Record<PanelId, number | undefined>;
+}
+
+export interface UsePanelLayoutOptions {
+  storageKey: string;
+  defaultState: PanelLayoutState;
+  panelOrder: PanelId[];
+}
+
+const noopLayout: PanelLayoutState = {
+  columns: {},
+  collapsed: {},
+  heights: {},
+};
+
+const DATA_VERSION = 1;
+
+interface StoredLayout {
+  version: number;
+  state: PanelLayoutState;
+}
+
+function normaliseLayout(
+  incoming: PanelLayoutState | undefined,
+  fallback: PanelLayoutState,
+  panelOrder: PanelId[],
+): PanelLayoutState {
+  const result: PanelLayoutState = {
+    columns: {},
+    collapsed: {},
+    heights: {},
+  };
+
+  const validPanelIds = new Set(panelOrder);
+  const placedPanels = new Set<PanelId>();
+  const fallbackColumns = fallback.columns ?? {};
+  const incomingColumns = incoming?.columns ?? {};
+  const allColumnKeys = Array.from(
+    new Set<ColumnId>([...Object.keys(fallbackColumns), ...Object.keys(incomingColumns)]),
+  );
+
+  for (const columnKey of allColumnKeys) {
+    result.columns[columnKey] = [];
+  }
+
+  for (const columnKey of allColumnKeys) {
+    const targetList = result.columns[columnKey]!;
+    const sourceList = incomingColumns[columnKey] ?? [];
+    for (const panelId of sourceList) {
+      if (!validPanelIds.has(panelId) || placedPanels.has(panelId)) {
+        continue;
+      }
+      targetList.push(panelId);
+      placedPanels.add(panelId);
+    }
+  }
+
+  for (const [columnKey, fallbackList] of Object.entries(fallbackColumns)) {
+    const targetList = result.columns[columnKey] ?? (result.columns[columnKey] = []);
+    for (const panelId of fallbackList) {
+      if (!validPanelIds.has(panelId) || placedPanels.has(panelId)) {
+        continue;
+      }
+      targetList.push(panelId);
+      placedPanels.add(panelId);
+    }
+  }
+
+  const remainingPanels = panelOrder.filter((panelId) => !placedPanels.has(panelId));
+  if (remainingPanels.length > 0) {
+    const firstColumnKey =
+      Object.keys(result.columns)[0] ??
+      Object.keys(fallbackColumns)[0] ??
+      Object.keys(incomingColumns)[0] ??
+      'default';
+    const targetList = result.columns[firstColumnKey] ?? (result.columns[firstColumnKey] = []);
+    targetList.push(...remainingPanels);
+  }
+
+  const candidateCollapsed = { ...(fallback.collapsed ?? {}), ...(incoming?.collapsed ?? {}) };
+  for (const [panelId, collapsed] of Object.entries(candidateCollapsed)) {
+    if (!validPanelIds.has(panelId)) {
+      continue;
+    }
+    if (typeof collapsed === 'boolean') {
+      result.collapsed[panelId] = collapsed;
+    }
+  }
+
+  const candidateHeights = { ...(fallback.heights ?? {}), ...(incoming?.heights ?? {}) };
+  for (const [panelId, height] of Object.entries(candidateHeights)) {
+    if (!validPanelIds.has(panelId)) {
+      continue;
+    }
+    if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
+      result.heights[panelId] = height;
+    }
+  }
+
+  return result;
+}
+
+export function repositionPanel(
+  columns: PanelLayoutState['columns'],
+  panelId: PanelId,
+  targetColumn: ColumnId,
+  targetIndex: number,
+): PanelLayoutState['columns'] {
+  const nextColumns: PanelLayoutState['columns'] = {};
+  for (const [columnKey, panelIds] of Object.entries(columns)) {
+    nextColumns[columnKey] = panelIds.filter((candidate) => candidate !== panelId);
+  }
+  const column = nextColumns[targetColumn] ?? (nextColumns[targetColumn] = []);
+  const clampedIndex = Math.max(0, Math.min(targetIndex, column.length));
+  column.splice(clampedIndex, 0, panelId);
+  return nextColumns;
+}
+
+export function usePanelLayout(options: UsePanelLayoutOptions) {
+  const { storageKey, defaultState, panelOrder } = options;
+  const stablePanelOrder = useMemo(() => [...panelOrder], [panelOrder]);
+
+  const [state, setState] = useState<PanelLayoutState>(() =>
+    normaliseLayout(undefined, defaultState, stablePanelOrder),
+  );
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) {
+        setState(normaliseLayout(undefined, defaultState, stablePanelOrder));
+        setHydrated(true);
+        return;
+      }
+      const decoded = JSON.parse(raw) as StoredLayout | PanelLayoutState;
+      const candidateState =
+        'version' in decoded && decoded.version === DATA_VERSION ? decoded.state : decoded;
+      setState(normaliseLayout(candidateState, defaultState, stablePanelOrder));
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Failed to restore panel layout from localStorage', error);
+      }
+      setState(normaliseLayout(undefined, defaultState, stablePanelOrder));
+    } finally {
+      setHydrated(true);
+    }
+  }, [defaultState, stablePanelOrder, storageKey]);
+
+  useEffect(() => {
+    if (!hydrated || typeof window === 'undefined') {
+      return;
+    }
+    try {
+      const payload: StoredLayout = {
+        version: DATA_VERSION,
+        state,
+      };
+      window.localStorage.setItem(storageKey, JSON.stringify(payload));
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Unable to persist panel layout', error);
+      }
+    }
+  }, [hydrated, state, storageKey]);
+
+  const movePanel = useCallback(
+    (panelId: PanelId, targetColumn: ColumnId, targetIndex: number) => {
+      setState((previous) => {
+        if (!panelId) {
+          return previous;
+        }
+        const nextColumns = repositionPanel(previous.columns, panelId, targetColumn, targetIndex);
+        return {
+          ...previous,
+          columns: nextColumns,
+        };
+      });
+    },
+    [],
+  );
+
+  const toggleCollapse = useCallback((panelId: PanelId) => {
+    setState((previous) => ({
+      ...previous,
+      collapsed: {
+        ...previous.collapsed,
+        [panelId]: !previous.collapsed?.[panelId],
+      },
+    }));
+  }, []);
+
+  const setCollapsed = useCallback((panelId: PanelId, collapsed: boolean | undefined) => {
+    setState((previous) => ({
+      ...previous,
+      collapsed: {
+        ...previous.collapsed,
+        [panelId]: collapsed,
+      },
+    }));
+  }, []);
+
+  const setPanelHeight = useCallback((panelId: PanelId, height: number | undefined) => {
+    setState((previous) => {
+      const nextHeights = { ...previous.heights };
+      if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
+        nextHeights[panelId] = height;
+      } else {
+        delete nextHeights[panelId];
+      }
+      return {
+        ...previous,
+        heights: nextHeights,
+      };
+    });
+  }, []);
+
+  const resetLayout = useCallback(() => {
+    setState(normaliseLayout(undefined, defaultState, stablePanelOrder));
+  }, [defaultState, stablePanelOrder]);
+
+  return {
+    state,
+    hydrated,
+    actions: {
+      movePanel,
+      toggleCollapse,
+      setCollapsed,
+      setPanelHeight,
+      resetLayout,
+    },
+  };
+}
+
+export type UsePanelLayoutReturn = ReturnType<typeof usePanelLayout>;
+
+export const __test__normaliseLayout = normaliseLayout;

--- a/web/src/tests/unit/panelLayout.test.tsx
+++ b/web/src/tests/unit/panelLayout.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  __test__normaliseLayout,
+  repositionPanel,
+  type PanelLayoutState,
+} from '@/components/shared/panels/usePanelLayout';
+
+const PANEL_ORDER = ['alpha', 'bravo', 'charlie', 'delta'] as const;
+
+const DEFAULT_STATE: PanelLayoutState = {
+  columns: {
+    primary: ['alpha', 'bravo'],
+    secondary: ['charlie'],
+    tertiary: ['delta'],
+  },
+  collapsed: {},
+  heights: {},
+};
+
+describe('repositionPanel', () => {
+  it('moves a panel into the requested column and position', () => {
+    const nextColumns = repositionPanel(DEFAULT_STATE.columns, 'bravo', 'secondary', 0);
+    expect(nextColumns.secondary[0]).toBe('bravo');
+    expect(nextColumns.primary).not.toContain('bravo');
+  });
+
+  it('appends to the target column when index exceeds bounds', () => {
+    const nextColumns = repositionPanel(DEFAULT_STATE.columns, 'alpha', 'secondary', 99);
+    expect(nextColumns.secondary[nextColumns.secondary.length - 1]).toBe('alpha');
+  });
+});
+
+describe('normaliseLayout', () => {
+  it('merges stored layout with new panels from the default state', () => {
+    const storedState: PanelLayoutState = {
+      columns: {
+        primary: ['bravo'],
+        secondary: [],
+      },
+      collapsed: { bravo: true },
+      heights: {},
+    };
+
+    const normalised = __test__normaliseLayout(storedState, DEFAULT_STATE, Array.from(PANEL_ORDER));
+
+    expect(normalised.columns.primary).toContain('bravo');
+    expect(normalised.columns.primary).toContain('alpha');
+    expect(normalised.columns.tertiary).toContain('delta');
+  });
+
+  it('filters invalid collapsed and height values', () => {
+    const storedState: PanelLayoutState = {
+      columns: DEFAULT_STATE.columns,
+      collapsed: { alpha: 'yes' as unknown as boolean },
+      heights: { alpha: -10 },
+    };
+
+    const normalised = __test__normaliseLayout(storedState, DEFAULT_STATE, Array.from(PANEL_ORDER));
+
+    expect(normalised.collapsed.alpha).toBeUndefined();
+    expect(normalised.heights.alpha).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- persist panel order, collapse state, and heights with a shared panel layout hook
- wrap studio sections in draggable, collapsible InteractivePanel shells so everything can be moved or hidden
- cover the layout helpers with unit tests and document memory workaround for full vitest runs

## Testing
- npx vitest run src/tests/unit/panelLayout.test.tsx
- npm test # fails under default heap; rerun with NODE_OPTIONS="--max-old-space-size=6144" npm test