### PR TITLE
Enable draggable studio panels

### DIFF
--- a/web/src/components/transit/TransitTranscriptionPanel.tsx
+++ b/web/src/components/transit/TransitTranscriptionPanel.tsx
@@ -34,6 +34,8 @@ import { ThemePanel } from '@/components/settings/ThemePanel';
 import { CompactPanel } from '@/components/settings/CompactPanel';
 import { NotificationPanel } from '@/components/settings/NotificationPanel';
 import { CollapsibleSection } from '@/components/shared/CollapsibleSection';
+import { WorkspaceColumn } from '@/components/workspace/WorkspaceColumn';
+import { useWorkspaceLayoutStore, type WorkspacePanelId } from '@/modules/workspaceLayout/store';
 
 const stageLabels: Record<string, string> = {
   idle: 'Ready',
@@ -142,6 +144,9 @@ export function TransitTranscriptionPanel() {
   const historyHydrated = useTransitTranscriptionHistoryStore((state) => state.hydrated);
   const historyError = useTransitTranscriptionHistoryStore((state) => state.error);
   const historyActions = useTransitTranscriptionHistoryStore((state) => state.actions);
+  const workspaceLayout = useWorkspaceLayoutStore((state) => state.layout);
+  const syncWorkspaceLayout = useWorkspaceLayoutStore((state) => state.actions.syncWithDefaults);
+  const resetWorkspaceLayout = useWorkspaceLayoutStore((state) => state.actions.reset);
 
   const [isRecorderSupported, setRecorderSupported] = useState<boolean>(false);
   const [isPreparingRecorder, setPreparingRecorder] = useState(false);
@@ -175,6 +180,10 @@ export function TransitTranscriptionPanel() {
   useEffect(() => {
     setRecorderSupported(isMediaRecorderSupported());
   }, []);
+
+  useEffect(() => {
+    syncWorkspaceLayout();
+  }, [syncWorkspaceLayout]);
 
   useEffect(() => {
     if (historyHydrated) {
@@ -470,7 +479,8 @@ export function TransitTranscriptionPanel() {
     setCalendarNotes('');
     setCalendarDuration('');
     setCalendarWindow('');
-  }, [actions, resetInteraction]);
+    resetWorkspaceLayout();
+  }, [actions, resetInteraction, resetWorkspaceLayout]);
 
   const handleHistoryLoad = useCallback(
     (historyRecord: TransitTranscriptionRecord) => {
@@ -528,6 +538,533 @@ export function TransitTranscriptionPanel() {
     }
   }, [historyActions, historyClearing, sortedHistoryRecords.length]);
 
+  const panelComponents: Record<WorkspacePanelId, ReactNode> = {
+    capture: (
+      <WorkspaceSection
+        id="capture"
+        title="Capture audio"
+        className="flex flex-col gap-4 rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
+        actions={
+          isRecording ? (
+            <span className="flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.25em] text-red-500">
+              Recording…
+            </span>
+          ) : null
+        }
+      >
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold text-charcoal-900">Capture audio</h3>
+        </div>
+        {isRecorderSupported ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={isRecording ? handleStopRecording : handleStartRecording}
+                className={`rounded-full px-4 py-2 text-sm font-medium shadow transition ${
+                  isRecording ? 'bg-red-500 text-cream-50 hover:bg-red-600' : 'bg-accent-600 text-cream-50 hover:bg-accent-700'
+                } ${isPreparingRecorder ? 'opacity-60' : ''}`}
+                disabled={isPreparingRecorder}
+              >
+                {isRecording ? 'Stop recording' : 'Start recording'}
+              </button>
+              {isRecording && (
+                <button
+                  type="button"
+                  onClick={handleCancelRecording}
+                  className="rounded-full border border-charcoal-300 px-3 py-2 text-sm font-medium text-charcoal-600 hover:bg-charcoal-100/70"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+            <p className="text-xs text-charcoal-500">
+              {isRecording
+                ? 'Recording in progress — stop to transcribe the captured audio.'
+                : 'Start recording to capture live audio. Upload a file instead if you have an existing clip.'}
+            </p>
+            <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-charcoal-200/70 px-4 py-3 text-sm text-charcoal-700">
+              <p>
+                Save the recording as{' '}
+                <span className="font-semibold text-charcoal-900">
+                  {title.trim() ? `"${title}"` : 'Untitled capture'}
+                </span>
+              </p>
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-500">
+                Title
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(event) => actions.setTitle(event.target.value)}
+                  className="rounded-full border border-charcoal-200/70 px-3 py-1.5 text-sm text-charcoal-900 shadow-inner focus:border-accent-500 focus:outline-none"
+                  placeholder="e.g. Depot safety briefing"
+                />
+              </label>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-charcoal-500">
+            Recording is not supported in this browser. Upload audio files instead.
+          </p>
+        )}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            className="rounded-full border border-charcoal-300 px-4 py-2 text-sm font-medium text-charcoal-700 hover:bg-charcoal-100/70"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isStreaming}
+          >
+            Choose file…
+          </button>
+          <input ref={fileInputRef} type="file" accept="audio/*" className="hidden" onChange={handleFilePick} />
+        </div>
+      </WorkspaceSection>
+    ),
+    cleanupInstructions: (
+      <WorkspaceSection
+        id="cleanup-controls"
+        title="Cleanup instructions"
+        className="flex flex-col gap-4 rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
+      >
+        <h3 className="text-sm font-semibold text-charcoal-900">Cleanup instructions</h3>
+        <p className="text-xs text-charcoal-500">
+          Ask the assistant to polish each transcript—for example Australian English, professional tone, or meeting-ready notes.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          {cleanupPresets.map((preset) => {
+            const isActive = cleanupLabel === preset.label;
+            return (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => actions.setCleanupInstruction(preset.instruction, preset.label)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                  isActive
+                    ? 'border-accent-600 bg-accent-600 text-cream-50 shadow-sm shadow-accent-200/60'
+                    : 'border-charcoal-300 text-charcoal-600 hover:border-accent-500 hover:text-accent-600'
+                }`}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() => actions.setCleanupInstruction('', undefined)}
+            className="rounded-full border border-transparent px-3 py-1 text-xs font-medium text-charcoal-500 transition hover:text-charcoal-700 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!hasCleanupInstruction}
+          >
+            Clear
+          </button>
+        </div>
+        <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
+          Custom instruction
+          <textarea
+            value={cleanupInstruction}
+            onChange={(event) => actions.setCleanupInstruction(event.target.value, undefined)}
+            className="min-h-[96px] rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner transition focus:border-accent-500 focus:outline-none"
+            placeholder="e.g. Make this transcript conform to Australian English standards and read like a formal briefing."
+          />
+        </label>
+        <p className="text-xs text-charcoal-500">
+          {hasCleanupInstruction
+            ? 'Cleanup runs automatically after transcription completes. The polished version appears in the Cleanup panel.'
+            : 'Add an instruction to generate a polished version alongside the raw transcript.'}
+        </p>
+      </WorkspaceSection>
+    ),
+    importEntries: <ImportPanel />,
+    snippets: <SnippetPanel />,
+    transcriptHistory: (
+      <WorkspaceSection
+        id="transcript-history"
+        title="Transcript history"
+        className="rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
+        actions={
+          <button
+            type="button"
+            className="rounded-full border border-rose-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-rose-700 hover:bg-rose-50 disabled:opacity-40"
+            onClick={() => void handleHistoryClear()}
+            disabled={historyClearing || sortedHistoryRecords.length === 0}
+          >
+            Clear
+          </button>
+        }
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold text-charcoal-900">Transcript history</h3>
+        </div>
+        {historyStatus && <p className="mt-2 text-xs text-charcoal-500">{historyStatus}</p>}
+        {!historyHydrated && <p className="mt-3 text-sm text-charcoal-500">Loading transcript history…</p>}
+        {historyHydrated && historyError && (
+          <p className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">{historyError}</p>
+        )}
+        {historyHydrated && !historyError && (
+          sortedHistoryRecords.length === 0 ? (
+            <p className="mt-3 text-sm text-charcoal-500">Transcribe audio to start building your history.</p>
+          ) : (
+            <div className="mt-3 space-y-4">
+              {sortedHistoryRecords.map((historyRecord) => (
+                <article
+                  key={historyRecord.id}
+                  className="rounded-xl border border-charcoal-200/70 bg-cream-50/80 p-3 shadow-inner shadow-charcoal-200/30"
+                >
+                  <header className="flex flex-wrap items-center justify-between gap-2">
+                    <h4 className="text-sm font-semibold text-charcoal-900">
+                      {historyRecord.title || 'Untitled transcript'}
+                    </h4>
+                    <FormattedTimestamp value={historyRecord.createdAt} className="text-xs text-charcoal-500" />
+                  </header>
+                  <p className="mt-2 line-clamp-3 text-sm text-charcoal-600">
+                    {historyRecord.summary?.summary ?? historyRecord.transcript}
+                  </p>
+                  {historyRecord.cleanup && (
+                    <p className="mt-1 text-xs text-charcoal-500">
+                      Cleanup: {historyRecord.cleanup.label ?? 'Custom instructions'}
+                    </p>
+                  )}
+                  <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-charcoal-500">
+                    <span className="capitalize text-charcoal-700">{historyRecord.source}</span>
+                    <span className="text-charcoal-700">
+                      Duration: {formatMilliseconds(historyRecord.durationMs)}
+                    </span>
+                    <span className="text-charcoal-700">Segments: {historyRecord.segments.length}</span>
+                    <span className="text-charcoal-700">
+                      Confidence:{' '}
+                      {typeof historyRecord.confidence === 'number' && Number.isFinite(historyRecord.confidence)
+                        ? `${Math.round(Math.max(0, Math.min(1, historyRecord.confidence)) * 100)}%`
+                        : 'Unknown'}
+                    </span>
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      className="rounded-full bg-charcoal-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-cream-50 hover:bg-charcoal-800"
+                      onClick={() => handleHistoryLoad(historyRecord)}
+                    >
+                      Load
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-full border border-charcoal-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-700 hover:bg-charcoal-100/70"
+                      onClick={() => handleHistoryDownload(historyRecord)}
+                    >
+                      Download
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-full border border-rose-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-rose-700 hover:bg-rose-50 disabled:opacity-40"
+                      onClick={() => void handleHistoryRemove(historyRecord.id)}
+                      disabled={historyPendingId === historyRecord.id}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )
+        )}
+      </WorkspaceSection>
+    ),
+    transcript: (
+      <WorkspaceSection
+        id="transcript-view"
+        title="Transcript"
+        className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
+        minHeight={240}
+        maxHeight={720}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold text-charcoal-900">Transcript</h3>
+          {record?.durationMs ? (
+            <span className="text-xs text-charcoal-500">Duration: {formatMilliseconds(record.durationMs)}</span>
+          ) : null}
+        </div>
+        <div className="mt-4 max-h-72 overflow-y-auto rounded-xl border border-charcoal-100/80 bg-cream-50/90 px-4 py-3 text-sm text-charcoal-800">
+          {transcriptText || record?.transcript ? (
+            <p className="whitespace-pre-line">{record?.transcript ?? transcriptText}</p>
+          ) : (
+            <p className="text-charcoal-400">Segments will appear here once transcription starts.</p>
+          )}
+        </div>
+        {segments.length > 0 && (
+          <ol className="mt-4 space-y-3">
+            {segments.map((segment) => (
+              <li
+                key={segment.index}
+                className="rounded-lg border border-charcoal-100/80 bg-white px-3 py-2 text-sm text-charcoal-800 shadow-sm"
+              >
+                <div className="flex items-center justify-between text-xs text-charcoal-500">
+                  <span>Segment {segment.index}</span>
+                  <span>
+                    {formatMilliseconds(segment.startMs)} – {formatMilliseconds(segment.endMs)}
+                  </span>
+                </div>
+                <p className="mt-1">{segment.text}</p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </WorkspaceSection>
+    ),
+    summary: (
+      <WorkspaceSection
+        title="Summary"
+        className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
+      >
+        <h3 className="text-sm font-semibold text-charcoal-900">Summary</h3>
+        {summary?.summary ? (
+          <p className="mt-2 text-sm text-charcoal-700">{summary.summary}</p>
+        ) : (
+          <p className="mt-2 text-sm text-charcoal-400">Insights will appear here after transcription.</p>
+        )}
+      </WorkspaceSection>
+    ),
+    cleanupResult: (
+      <WorkspaceSection
+        title="Cleanup result"
+        className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-semibold text-charcoal-900">Cleanup result</h3>
+          {cleanupResult ? (
+            <span className="rounded-full bg-accent-100 px-2 py-0.5 text-[11px] font-medium text-accent-700">
+              {cleanupResult.label ?? 'Custom instructions'}
+            </span>
+          ) : hasCleanupInstruction ? (
+            <span className="rounded-full bg-charcoal-100 px-2 py-0.5 text-[11px] font-medium text-charcoal-600">
+              Pending
+            </span>
+          ) : null}
+        </div>
+        {cleanupResult ? (
+          <>
+            {!cleanupResult.label && (
+              <p className="mt-2 text-xs text-charcoal-500">Instruction: {cleanupResult.instruction}</p>
+            )}
+            <p className="mt-3 whitespace-pre-line text-sm text-charcoal-700">{cleanupResult.output}</p>
+          </>
+        ) : hasCleanupInstruction ? (
+          <p className="mt-2 text-sm text-charcoal-400">
+            {stage === 'cleaning' || isStreaming
+              ? 'Applying cleanup instructions…'
+              : 'Run a transcription to generate a polished version with the current instructions.'}
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-charcoal-400">
+            Add instructions to generate a polished version alongside the raw transcript.
+          </p>
+        )}
+      </WorkspaceSection>
+    ),
+    actionItems: (
+      <WorkspaceSection
+        title="Action items"
+        className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
+      >
+        <h3 className="text-sm font-semibold text-charcoal-900">Action items</h3>
+        {summary?.actionItems && summary.actionItems.length > 0 ? (
+          <ul className="mt-2 space-y-2">
+            {summary.actionItems.map((item, index) => (
+              <SummaryActionItem key={`${item.text}-${index}`} item={item} />
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-sm text-charcoal-400">No action items detected.</p>
+        )}
+      </WorkspaceSection>
+    ),
+    scheduleSuggestion: (
+      <WorkspaceSection
+        title="Suggested calendar event"
+        className="rounded-2xl border border-accent-500/40 bg-accent-50/80 p-4 shadow-sm shadow-accent-200/50"
+      >
+        <h3 className="text-sm font-semibold text-accent-800">Suggested calendar event</h3>
+        {summary?.scheduleRecommendation ? (
+          <>
+            <p className="mt-2 text-sm text-accent-800">{summary.scheduleRecommendation.title}</p>
+            {(summary.scheduleRecommendation.startWindow ||
+              summary.scheduleRecommendation.durationMinutes ||
+              (summary.scheduleRecommendation.participants?.length ?? 0) > 0) && (
+              <ul className="mt-2 space-y-1 text-xs text-accent-700">
+                {summary.scheduleRecommendation.startWindow && (
+                  <li>Window: {summary.scheduleRecommendation.startWindow}</li>
+                )}
+                {summary.scheduleRecommendation.durationMinutes && (
+                  <li>Duration: {summary.scheduleRecommendation.durationMinutes} minutes</li>
+                )}
+                {summary.scheduleRecommendation.participants &&
+                  summary.scheduleRecommendation.participants.length > 0 && (
+                    <li>Participants: {summary.scheduleRecommendation.participants.join(', ')}</li>
+                  )}
+              </ul>
+            )}
+          </>
+        ) : (
+          <p className="mt-2 text-sm text-accent-700">
+            Schedule recommendations appear after a transcription includes actionable follow-up.
+          </p>
+        )}
+      </WorkspaceSection>
+    ),
+    calendar: (
+      <WorkspaceSection
+        id="calendar"
+        title="Calendar follow-up"
+        className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
+        actions={
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] ${
+              calendarConnected ? 'bg-emerald-100 text-emerald-700' : 'bg-charcoal-100 text-charcoal-600'
+            }`}
+          >
+            {calendarConnected ? 'Google calendar connected' : 'Not connected'}
+          </span>
+        }
+      >
+        <h3 className="text-sm font-semibold text-charcoal-900">Calendar follow-up</h3>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void handleConnectCalendar()}
+            className="rounded-full border border-charcoal-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-700 hover:bg-charcoal-100/70 disabled:opacity-40"
+            disabled={isConnectingCalendar}
+          >
+            {isConnectingCalendar ? 'Connecting…' : calendarConnected ? 'Reconnect Google Calendar' : 'Connect Google Calendar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => void refreshCalendarStatus()}
+            className="rounded-full border border-charcoal-200 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-700 hover:bg-charcoal-100/70"
+          >
+            Refresh status
+          </button>
+        </div>
+        <form className="mt-4 flex flex-col gap-3" onSubmit={handleCalendarSubmit}>
+          <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
+            Event title
+            <input
+              type="text"
+              value={calendarTitle}
+              onChange={(event) => {
+                setCalendarTitle(event.target.value);
+                setCalendarStatus('idle');
+              }}
+              className="rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
+              placeholder="e.g. Transit follow-up"
+              disabled={calendarFormDisabled}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
+            Preferred start window
+            <input
+              type="text"
+              value={calendarWindow}
+              onChange={(event) => {
+                setCalendarWindow(event.target.value);
+                setCalendarStatus('idle');
+              }}
+              className="rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
+              placeholder="Tomorrow between 2–4pm"
+              disabled={calendarFormDisabled}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
+            Duration (minutes)
+            <input
+              type="number"
+              min={0}
+              value={calendarDuration}
+              onChange={(event) => {
+                const next = event.target.valueAsNumber;
+                setCalendarDuration(Number.isFinite(next) ? next : '');
+                setCalendarStatus('idle');
+              }}
+              className="w-32 rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
+              placeholder="45"
+              disabled={calendarFormDisabled}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
+            Participants (one per line)
+            <textarea
+              value={calendarParticipants}
+              onChange={(event) => {
+                setCalendarParticipants(event.target.value);
+                setCalendarStatus('idle');
+              }}
+              className="min-h-[96px] rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
+              placeholder="alex@example.com&#10;dispatch.lead@example.com"
+              disabled={calendarFormDisabled}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
+            Notes
+            <textarea
+              value={calendarNotes}
+              onChange={(event) => {
+                setCalendarNotes(event.target.value);
+                setCalendarStatus('idle');
+              }}
+              className="min-h-[72px] rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
+              placeholder="Key agenda points or links"
+              disabled={calendarFormDisabled}
+            />
+          </label>
+          <button
+            type="submit"
+            className="self-start rounded-full bg-accent-600 px-4 py-2 text-sm font-medium text-cream-50 transition hover:bg-accent-700 disabled:cursor-not-allowed disabled:bg-charcoal-300"
+            disabled={calendarStatus === 'saving' || calendarFormDisabled}
+          >
+            {isAuthenticated
+              ? calendarFormDisabled
+                ? 'Connect Google Calendar'
+                : calendarStatus === 'saving'
+                  ? 'Scheduling…'
+                  : 'Schedule Google Calendar event'
+              : 'Sign in to schedule'}
+          </button>
+        </form>
+        {calendarConnectionError && (
+          <p className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            {calendarConnectionError}
+          </p>
+        )}
+        {calendarFormError && (
+          <p className="mt-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700">
+            {calendarFormError}
+          </p>
+        )}
+        {calendarInfoMessage && calendarStatus !== 'success' && (
+          <p className="mt-3 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+            {calendarInfoMessage}
+          </p>
+        )}
+        {calendarStatus === 'success' && (
+          <p className="mt-3 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+            Event scheduled in Google Calendar.
+          </p>
+        )}
+      </WorkspaceSection>
+    ),
+    provider: <ProviderSelector />,
+    scriptEditor: <TextEditor />,
+    translationControls: <TranslationControls />,
+    generate: <GenerateButton />,
+    playback: <PlaybackControls />,
+    batchQueue: <BatchPanel />,
+    pronunciation: <PronunciationPanel />,
+    ttsHistory: <HistoryPanel />,
+    translationHistory: <TranslationHistoryPanel />,
+    credentials: <CredentialsPanel />,
+    theme: <ThemePanel />,
+    compact: <CompactPanel />,
+    notifications: <NotificationPanel />,
+  };
+
+  const renderPanel = (panelId: WorkspacePanelId): ReactNode => panelComponents[panelId] ?? null;
+
   return (
     <CollapsibleSection
       title="Narration Studio"
@@ -577,514 +1114,15 @@ export function TransitTranscriptionPanel() {
       </WorkspaceSection>
 
       <div className="mt-8 grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)_360px] lg:grid-cols-[300px_minmax(0,1fr)]">
-        <div className="flex flex-col gap-6">
-          <WorkspaceSection
-            id="capture"
-            title="Capture audio"
-            className="flex flex-col gap-4 rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
-            actions={
-              isRecording ? (
-                <span className="flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.25em] text-red-500">
-                  Recording…
-                </span>
-              ) : null
-            }
-          >
-            <div className="flex items-center justify-between gap-2">
-              <h3 className="text-sm font-semibold text-charcoal-900">Capture audio</h3>
-            </div>
-            {isRecorderSupported ? (
-              <div className="flex flex-col gap-3">
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={isRecording ? handleStopRecording : handleStartRecording}
-                    className={`rounded-full px-4 py-2 text-sm font-medium shadow transition ${
-                      isRecording
-                        ? 'bg-red-500 text-cream-50 hover:bg-red-600'
-                        : 'bg-accent-600 text-cream-50 hover:bg-accent-700'
-                    } ${isPreparingRecorder ? 'opacity-60' : ''}`}
-                    disabled={isPreparingRecorder}
-                  >
-                    {isRecording ? 'Stop recording' : 'Start recording'}
-                  </button>
-                  {isRecording && (
-                    <button
-                      type="button"
-                      onClick={handleCancelRecording}
-                      className="rounded-full border border-charcoal-300 px-3 py-2 text-sm font-medium text-charcoal-600 hover:bg-charcoal-100/70"
-                    >
-                      Cancel
-                    </button>
-                  )}
-                </div>
-                <p className="text-xs text-charcoal-500">
-                  {isRecording
-                    ? 'Recording… stop when you are ready to transcribe.'
-                    : 'Allow microphone access to capture live communications.'}
-                </p>
-              </div>
-            ) : (
-              <p className="rounded-lg border border-amber-400 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                Microphone recording is not supported in this browser. Use the upload option instead.
-              </p>
-            )}
-          </WorkspaceSection>
-
-          <WorkspaceSection
-            title="Upload audio file"
-            className="flex flex-col gap-4 rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
-          >
-            <h3 className="text-sm font-semibold text-charcoal-900">Upload audio file</h3>
-            <p className="text-xs text-charcoal-500">MP3, WAV, or M4A up to 25 MB.</p>
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="w-fit rounded-full border border-dashed border-charcoal-300 px-4 py-2 text-sm font-medium text-charcoal-700 hover:border-accent-500 hover:text-accent-600"
-            >
-              Choose file…
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="audio/*"
-              className="hidden"
-              onChange={handleFilePick}
-            />
-          </WorkspaceSection>
-
-          <WorkspaceSection
-            id="cleanup-controls"
-            title="Cleanup instructions"
-            className="flex flex-col gap-4 rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
-          >
-            <h3 className="text-sm font-semibold text-charcoal-900">Cleanup instructions</h3>
-            <p className="text-xs text-charcoal-500">
-              Ask the assistant to polish each transcript—for example Australian English, professional tone, or meeting-ready notes.
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              {cleanupPresets.map((preset) => {
-                const isActive = cleanupLabel === preset.label;
-                return (
-                  <button
-                    key={preset.label}
-                    type="button"
-                    onClick={() => actions.setCleanupInstruction(preset.instruction, preset.label)}
-                    className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
-                      isActive
-                        ? 'border-accent-600 bg-accent-600 text-cream-50 shadow-sm shadow-accent-200/60'
-                        : 'border-charcoal-300 text-charcoal-600 hover:border-accent-500 hover:text-accent-600'
-                    }`}
-                  >
-                    {preset.label}
-                  </button>
-                );
-              })}
-              <button
-                type="button"
-                onClick={() => actions.setCleanupInstruction('', undefined)}
-                className="rounded-full border border-transparent px-3 py-1 text-xs font-medium text-charcoal-500 transition hover:text-charcoal-700 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={!hasCleanupInstruction}
-              >
-                Clear
-              </button>
-            </div>
-            <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
-              Custom instruction
-              <textarea
-                value={cleanupInstruction}
-                onChange={(event) => actions.setCleanupInstruction(event.target.value, undefined)}
-                className="min-h-[96px] rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner transition focus:border-accent-500 focus:outline-none"
-                placeholder="e.g. Make this transcript conform to Australian English standards and read like a formal briefing."
-              />
-            </label>
-            <p className="text-xs text-charcoal-500">
-              {hasCleanupInstruction
-                ? 'Cleanup runs automatically after transcription completes. The polished version appears in the Cleanup panel.'
-                : 'Add an instruction to generate a polished version alongside the raw transcript.'}
-            </p>
-          </WorkspaceSection>
-
-          <ImportPanel />
-          <SnippetPanel />
-
-          <WorkspaceSection
-            id="transcript-history"
-            title="Transcript history"
-            className="rounded-2xl border border-charcoal-200/70 bg-white/70 p-4 shadow-sm shadow-charcoal-200/50"
-            actions={
-              <button
-                type="button"
-                className="rounded-full border border-rose-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-rose-700 hover:bg-rose-50 disabled:opacity-40"
-                onClick={() => void handleHistoryClear()}
-                disabled={historyClearing || sortedHistoryRecords.length === 0}
-              >
-                Clear
-              </button>
-            }
-          >
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <h3 className="text-sm font-semibold text-charcoal-900">Transcript history</h3>
-            </div>
-            {historyStatus && <p className="mt-2 text-xs text-charcoal-500">{historyStatus}</p>}
-            {!historyHydrated && <p className="mt-3 text-sm text-charcoal-500">Loading transcript history…</p>}
-            {historyHydrated && historyError && (
-              <p className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">{historyError}</p>
-            )}
-            {historyHydrated && !historyError && (
-              sortedHistoryRecords.length === 0 ? (
-                <p className="mt-3 text-sm text-charcoal-500">Transcribe audio to start building your history.</p>
-              ) : (
-                <div className="mt-3 space-y-4">
-                  {sortedHistoryRecords.map((historyRecord) => (
-                    <article
-                      key={historyRecord.id}
-                      className="rounded-xl border border-charcoal-200/70 bg-cream-50/80 p-3 shadow-inner shadow-charcoal-200/30"
-                    >
-                      <header className="flex flex-wrap items-center justify-between gap-2">
-                        <h4 className="text-sm font-semibold text-charcoal-900">
-                          {historyRecord.title || 'Untitled transcript'}
-                        </h4>
-                        <FormattedTimestamp value={historyRecord.createdAt} className="text-xs text-charcoal-500" />
-                      </header>
-                      <p className="mt-2 line-clamp-3 text-sm text-charcoal-600">
-                        {historyRecord.summary?.summary ?? historyRecord.transcript}
-                      </p>
-                      {historyRecord.cleanup && (
-                        <p className="mt-1 text-xs text-charcoal-500">
-                          Cleanup: {historyRecord.cleanup.label ?? 'Custom instructions'}
-                        </p>
-                      )}
-                      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-charcoal-500">
-                        <span className="capitalize text-charcoal-700">{historyRecord.source}</span>
-                        <span className="text-charcoal-700">
-                          Duration: {formatMilliseconds(historyRecord.durationMs)}
-                        </span>
-                        <span className="text-charcoal-700">Segments: {historyRecord.segments.length}</span>
-                        <span className="text-charcoal-700">
-                          Confidence:{' '}
-                          {typeof historyRecord.confidence === 'number' && Number.isFinite(historyRecord.confidence)
-                            ? `${Math.round(Math.max(0, Math.min(1, historyRecord.confidence)) * 100)}%`
-                            : 'Unknown'}
-                        </span>
-                      </div>
-                      <div className="mt-3 flex flex-wrap items-center gap-2">
-                        <button
-                          type="button"
-                          className="rounded-full bg-charcoal-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-cream-50 hover:bg-charcoal-800"
-                          onClick={() => handleHistoryLoad(historyRecord)}
-                        >
-                          Load
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded-full border border-charcoal-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-charcoal-700 hover:bg-charcoal-100/70"
-                          onClick={() => handleHistoryDownload(historyRecord)}
-                        >
-                          Download
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded-full border border-rose-300 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-rose-700 hover:bg-rose-50 disabled:opacity-40"
-                          onClick={() => void handleHistoryRemove(historyRecord.id)}
-                          disabled={historyPendingId === historyRecord.id}
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    </article>
-                  ))}
-                </div>
-              )
-            )}
-          </WorkspaceSection>
-        </div>
-
-        <div className="flex flex-col gap-6">
-          <WorkspaceSection
-            id="transcript-view"
-            title="Transcript"
-            className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
-            minHeight={240}
-            maxHeight={720}
-          >
-            <div className="flex items-center justify-between gap-3">
-              <h3 className="text-sm font-semibold text-charcoal-900">Transcript</h3>
-              {record?.durationMs ? (
-                <span className="text-xs text-charcoal-500">Duration: {formatMilliseconds(record.durationMs)}</span>
-              ) : null}
-            </div>
-            <div className="mt-4 max-h-72 overflow-y-auto rounded-xl border border-charcoal-100/80 bg-cream-50/90 px-4 py-3 text-sm text-charcoal-800">
-              {transcriptText || record?.transcript ? (
-                <p className="whitespace-pre-line">{record?.transcript ?? transcriptText}</p>
-              ) : (
-                <p className="text-charcoal-400">Segments will appear here once transcription starts.</p>
-              )}
-            </div>
-            {segments.length > 0 && (
-              <ol className="mt-4 space-y-3">
-                {segments.map((segment) => (
-                  <li
-                    key={segment.index}
-                    className="rounded-lg border border-charcoal-100/80 bg-white px-3 py-2 text-sm text-charcoal-800 shadow-sm"
-                  >
-                    <div className="flex items-center justify-between text-xs text-charcoal-500">
-                      <span>Segment {segment.index}</span>
-                      <span>
-                        {formatMilliseconds(segment.startMs)} – {formatMilliseconds(segment.endMs)}
-                      </span>
-                    </div>
-                    <p className="mt-1">{segment.text}</p>
-                  </li>
-                ))}
-              </ol>
-            )}
-          </WorkspaceSection>
-
-          <WorkspaceSection
-            title="Summary"
-            className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
-          >
-            <h3 className="text-sm font-semibold text-charcoal-900">Summary</h3>
-            {summary?.summary ? (
-              <p className="mt-2 text-sm text-charcoal-700">{summary.summary}</p>
-            ) : (
-              <p className="mt-2 text-sm text-charcoal-400">Insights will appear here after transcription.</p>
-            )}
-          </WorkspaceSection>
-
-          <WorkspaceSection
-            title="Cleanup result"
-            className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
-          >
-            <div className="flex items-start justify-between gap-2">
-              <h3 className="text-sm font-semibold text-charcoal-900">Cleanup result</h3>
-              {cleanupResult ? (
-                <span className="rounded-full bg-accent-100 px-2 py-0.5 text-[11px] font-medium text-accent-700">
-                  {cleanupResult.label ?? 'Custom instructions'}
-                </span>
-              ) : hasCleanupInstruction ? (
-                <span className="rounded-full bg-charcoal-100 px-2 py-0.5 text-[11px] font-medium text-charcoal-600">
-                  Pending
-                </span>
-              ) : null}
-            </div>
-            {cleanupResult ? (
-              <>
-                {!cleanupResult.label && (
-                  <p className="mt-2 text-xs text-charcoal-500">Instruction: {cleanupResult.instruction}</p>
-                )}
-                <p className="mt-3 whitespace-pre-line text-sm text-charcoal-700">{cleanupResult.output}</p>
-              </>
-            ) : hasCleanupInstruction ? (
-              <p className="mt-2 text-sm text-charcoal-400">
-                {stage === 'cleaning' || isStreaming
-                  ? 'Applying cleanup instructions…'
-                  : 'Run a transcription to generate a polished version with the current instructions.'}
-              </p>
-            ) : (
-              <p className="mt-2 text-sm text-charcoal-400">
-                Add instructions to generate a polished version alongside the raw transcript.
-              </p>
-            )}
-          </WorkspaceSection>
-
-          <WorkspaceSection
-            title="Action items"
-            className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
-          >
-            <h3 className="text-sm font-semibold text-charcoal-900">Action items</h3>
-            {summary?.actionItems && summary.actionItems.length > 0 ? (
-              <ul className="mt-2 space-y-2">
-                {summary.actionItems.map((item, index) => (
-                  <SummaryActionItem key={`${item.text}-${index}`} item={item} />
-                ))}
-              </ul>
-            ) : (
-              <p className="mt-2 text-sm text-charcoal-400">No action items detected.</p>
-            )}
-          </WorkspaceSection>
-
-          {summary?.scheduleRecommendation && (
-            <WorkspaceSection
-              title="Suggested calendar event"
-              className="rounded-2xl border border-accent-500/40 bg-accent-50/80 p-4 shadow-sm shadow-accent-200/50"
-            >
-              <h3 className="text-sm font-semibold text-accent-800">Suggested calendar event</h3>
-              <p className="mt-2 text-sm text-accent-800">{summary.scheduleRecommendation.title}</p>
-              {(summary.scheduleRecommendation.startWindow ||
-                summary.scheduleRecommendation.durationMinutes ||
-                (summary.scheduleRecommendation.participants?.length ?? 0) > 0) && (
-                <ul className="mt-2 space-y-1 text-xs text-accent-700">
-                  {summary.scheduleRecommendation.startWindow && (
-                    <li>Window: {summary.scheduleRecommendation.startWindow}</li>
-                  )}
-                  {summary.scheduleRecommendation.durationMinutes && (
-                    <li>Duration: {summary.scheduleRecommendation.durationMinutes} minutes</li>
-                  )}
-                  {summary.scheduleRecommendation.participants &&
-                    summary.scheduleRecommendation.participants.length > 0 && (
-                      <li>Participants: {summary.scheduleRecommendation.participants.join(', ')}</li>
-                  )}
-                </ul>
-              )}
-            </WorkspaceSection>
-          )}
-
-          <WorkspaceSection
-            id="calendar"
-            title="Calendar follow-up"
-            className="rounded-2xl border border-charcoal-200/70 bg-white/80 p-4 shadow-sm shadow-charcoal-200/60"
-            actions={
-              <span
-                className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] ${
-                  calendarConnected ? 'bg-emerald-100 text-emerald-700' : 'bg-charcoal-100 text-charcoal-600'
-                }`}
-              >
-                {calendarConnected ? 'Google calendar connected' : 'Not connected'}
-              </span>
-            }
-          >
-            <h3 className="text-sm font-semibold text-charcoal-900">Calendar follow-up</h3>
-            <div className="mt-2 flex flex-wrap items-center gap-3">
-              <button
-                type="button"
-                onClick={handleConnectCalendar}
-                className="rounded-full border border-accent-500 px-4 py-1.5 text-xs font-medium text-accent-600 transition hover:bg-accent-50 disabled:cursor-not-allowed disabled:border-charcoal-300 disabled:text-charcoal-400"
-                disabled={isConnectingCalendar}
-              >
-                {isConnectingCalendar ? 'Opening…' : calendarConnected ? 'Reconnect' : 'Connect Google Calendar'}
-              </button>
-            </div>
-            <p className="mt-2 text-xs text-charcoal-500">
-              Enter attendees manually. Only the organiser is pre-filled from your signed-in account. Events use your configured Google Calendar timezone.
-            </p>
-            <form className="mt-3 flex flex-col gap-3" onSubmit={handleCalendarSubmit}>
-              <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
-                Title
-                <input
-                  type="text"
-                  value={calendarTitle}
-                  onChange={(event) => {
-                    setCalendarTitle(event.target.value);
-                    setCalendarStatus('idle');
-                  }}
-                  className="rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
-                  placeholder="e.g. Route 9 follow-up briefing"
-                  disabled={calendarFormDisabled}
-                  required
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
-                Preferred window
-                <input
-                  type="text"
-                  value={calendarWindow}
-                  onChange={(event) => {
-                    setCalendarWindow(event.target.value);
-                    setCalendarStatus('idle');
-                  }}
-                  className="rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
-                  placeholder="Tomorrow between 2–4pm"
-                  disabled={calendarFormDisabled}
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
-                Duration (minutes)
-                <input
-                  type="number"
-                  min={0}
-                  value={calendarDuration}
-                  onChange={(event) => {
-                    const next = event.target.valueAsNumber;
-                    setCalendarDuration(Number.isFinite(next) ? next : '');
-                    setCalendarStatus('idle');
-                  }}
-                  className="w-32 rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
-                  placeholder="45"
-                  disabled={calendarFormDisabled}
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
-                Participants (one per line)
-                <textarea
-                  value={calendarParticipants}
-                  onChange={(event) => {
-                    setCalendarParticipants(event.target.value);
-                    setCalendarStatus('idle');
-                  }}
-                  className="min-h-[96px] rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
-                  placeholder="alex@example.com&#10;dispatch.lead@example.com"
-                  disabled={calendarFormDisabled}
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs font-medium text-charcoal-700">
-                Notes
-                <textarea
-                  value={calendarNotes}
-                  onChange={(event) => {
-                    setCalendarNotes(event.target.value);
-                    setCalendarStatus('idle');
-                  }}
-                  className="min-h-[72px] rounded-lg border border-charcoal-200/70 bg-white px-3 py-2 text-sm text-charcoal-900 shadow-inner disabled:cursor-not-allowed disabled:bg-charcoal-100"
-                  placeholder="Key agenda points or links"
-                  disabled={calendarFormDisabled}
-                />
-              </label>
-              <button
-                type="submit"
-                className="self-start rounded-full bg-accent-600 px-4 py-2 text-sm font-medium text-cream-50 transition hover:bg-accent-700 disabled:cursor-not-allowed disabled:bg-charcoal-300"
-                disabled={calendarStatus === 'saving' || calendarFormDisabled}
-              >
-                {isAuthenticated
-                  ? calendarFormDisabled
-                    ? 'Connect Google Calendar'
-                    : calendarStatus === 'saving'
-                      ? 'Scheduling…'
-                      : 'Schedule Google Calendar event'
-                  : 'Sign in to schedule'}
-              </button>
-            </form>
-            {calendarConnectionError && (
-              <p className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-700">
-                {calendarConnectionError}
-              </p>
-            )}
-            {calendarFormError && (
-              <p className="mt-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700">
-                {calendarFormError}
-              </p>
-            )}
-            {calendarInfoMessage && calendarStatus !== 'success' && (
-              <p className="mt-3 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
-                {calendarInfoMessage}
-              </p>
-            )}
-            {calendarStatus === 'success' && (
-              <p className="mt-3 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
-                Event scheduled in Google Calendar.
-              </p>
-            )}
-          </WorkspaceSection>
-        </div>
-
-        <div id="tts-controls" className="flex flex-col gap-6">
-          <ProviderSelector />
-          <TextEditor />
-          <TranslationControls />
-          <GenerateButton />
-          <PlaybackControls />
-          <BatchPanel />
-          <PronunciationPanel />
-          <HistoryPanel />
-          <TranslationHistoryPanel />
-          <CredentialsPanel />
-          <ThemePanel />
-          <CompactPanel />
-          <NotificationPanel />
-        </div>
+        <WorkspaceColumn columnId="left" panelIds={workspaceLayout.left} renderPanel={renderPanel} />
+        <WorkspaceColumn columnId="center" panelIds={workspaceLayout.center} renderPanel={renderPanel} />
+        <WorkspaceColumn
+          columnId="right"
+          panelIds={workspaceLayout.right}
+          renderPanel={renderPanel}
+          containerId="tts-controls"
+        />
       </div>
-
       {!hasResults && (
         <div className="mt-6 rounded-2xl border border-charcoal-200/70 bg-white/70 p-6 text-sm text-charcoal-600 shadow-sm shadow-charcoal-200/60">
           <p>

--- a/web/src/components/workspace/WorkspaceColumn.tsx
+++ b/web/src/components/workspace/WorkspaceColumn.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import {
+  useWorkspaceLayoutStore,
+  type WorkspaceColumnId,
+  type WorkspacePanelId,
+  workspacePanelLabels,
+} from '@/modules/workspaceLayout/store';
+
+const DATA_FORMAT = 'application/x-workspace-panel';
+
+const getPanelIdFromEvent = (event: DragEvent | React.DragEvent): WorkspacePanelId | null => {
+  const primary = event.dataTransfer?.getData(DATA_FORMAT);
+  const fallback = event.dataTransfer?.getData('text/plain');
+  const value = (primary || fallback) as WorkspacePanelId | undefined;
+  if (!value) {
+    return null;
+  }
+  const isKnown = workspacePanelLabels[value] !== undefined;
+  return isKnown ? value : null;
+};
+
+interface WorkspaceColumnProps {
+  columnId: WorkspaceColumnId;
+  panelIds: WorkspacePanelId[];
+  renderPanel: (panelId: WorkspacePanelId) => ReactNode;
+  containerId?: string;
+  className?: string;
+}
+
+export function WorkspaceColumn({ columnId, panelIds, renderPanel, containerId, className }: WorkspaceColumnProps) {
+  const movePanel = useWorkspaceLayoutStore((state) => state.actions.movePanel);
+  const draggingPanelId = useWorkspaceLayoutStore((state) => state.draggingPanelId);
+  const stopDragging = useWorkspaceLayoutStore((state) => state.actions.stopDragging);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const panelId = getPanelIdFromEvent(event.nativeEvent);
+      if (!panelId) {
+        setDropIndex(null);
+        return;
+      }
+      const target = dropIndex ?? panelIds.length;
+      movePanel(panelId, columnId, target);
+      setDropIndex(null);
+      stopDragging();
+    },
+    [columnId, dropIndex, movePanel, panelIds.length, stopDragging],
+  );
+
+  const handleDragOverColumn = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!draggingPanelId) {
+        return;
+      }
+      event.preventDefault();
+      if (panelIds.length === 0) {
+        setDropIndex(0);
+      } else if (event.target === event.currentTarget) {
+        setDropIndex(panelIds.length);
+      }
+    },
+    [draggingPanelId, panelIds.length],
+  );
+
+  const handleDragLeaveColumn = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setDropIndex(null);
+    }
+  }, []);
+
+  const contents = useMemo(() => {
+    const nodes: ReactNode[] = [];
+    panelIds.forEach((panelId, index) => {
+      if (dropIndex === index) {
+        nodes.push(<WorkspaceDropIndicator key={`indicator-${columnId}-${index}`} />);
+      }
+      nodes.push(
+        <WorkspaceDraggablePanel
+          key={panelId}
+          panelId={panelId}
+          index={index}
+          columnId={columnId}
+          label={workspacePanelLabels[panelId]}
+          onHoverPosition={setDropIndex}
+          onHoverClear={() => setDropIndex(null)}
+        >
+          {renderPanel(panelId)}
+        </WorkspaceDraggablePanel>,
+      );
+    });
+
+    if (dropIndex === panelIds.length) {
+      nodes.push(<WorkspaceDropIndicator key={`indicator-${columnId}-end`} />);
+    }
+
+    return nodes;
+  }, [columnId, dropIndex, panelIds, renderPanel]);
+
+  return (
+    <div
+      id={containerId}
+      className={`flex flex-col gap-6 ${className ?? ''}`}
+      data-workspace-column={columnId}
+      onDrop={handleDrop}
+      onDragOver={handleDragOverColumn}
+      onDragLeave={handleDragLeaveColumn}
+    >
+      {contents}
+    </div>
+  );
+}
+
+interface WorkspaceDraggablePanelProps {
+  panelId: WorkspacePanelId;
+  columnId: WorkspaceColumnId;
+  index: number;
+  children: ReactNode;
+  label: string;
+  onHoverPosition: (index: number) => void;
+  onHoverClear: () => void;
+}
+
+function WorkspaceDraggablePanel({
+  panelId,
+  columnId,
+  index,
+  children,
+  label,
+  onHoverPosition,
+  onHoverClear,
+}: WorkspaceDraggablePanelProps) {
+  const startDragging = useWorkspaceLayoutStore((state) => state.actions.startDragging);
+  const stopDragging = useWorkspaceLayoutStore((state) => state.actions.stopDragging);
+  const draggingPanelId = useWorkspaceLayoutStore((state) => state.draggingPanelId);
+  const [isDraggable, setIsDraggable] = useState(false);
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!isDraggable) {
+        event.preventDefault();
+        return;
+      }
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData(DATA_FORMAT, panelId);
+      event.dataTransfer.setData('text/plain', panelId);
+      startDragging(panelId);
+      event.dataTransfer.setDragImage(event.currentTarget, 20, 20);
+    },
+    [isDraggable, panelId, startDragging],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    stopDragging();
+    setIsDraggable(false);
+    onHoverClear();
+  }, [onHoverClear, stopDragging]);
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!draggingPanelId) {
+        return;
+      }
+      event.preventDefault();
+      const bounds = event.currentTarget.getBoundingClientRect();
+      const offset = event.clientY - bounds.top;
+      const shouldInsertBefore = offset < bounds.height / 2;
+      onHoverPosition(shouldInsertBefore ? index : index + 1);
+    },
+    [draggingPanelId, index, onHoverPosition],
+  );
+
+  const handleDragLeave = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+        onHoverClear();
+      }
+    },
+    [onHoverClear],
+  );
+
+  const handlePointerDown = useCallback(() => {
+    setIsDraggable(true);
+  }, []);
+
+  const handlePointerUp = useCallback(() => {
+    setIsDraggable(false);
+  }, []);
+
+  const handlePointerLeave = useCallback(() => {
+    if (!draggingPanelId) {
+      setIsDraggable(false);
+    }
+  }, [draggingPanelId]);
+
+  const isDragging = draggingPanelId === panelId;
+
+  return (
+    <div
+      className={`relative ${isDragging ? 'opacity-60' : ''}`}
+      draggable={isDraggable}
+      data-workspace-panel={panelId}
+      data-workspace-column={columnId}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+    >
+      <button
+        type="button"
+        className={`absolute right-4 top-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-charcoal-200 bg-white/90 text-charcoal-600 shadow transition hover:bg-charcoal-100 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 ${
+          isDragging ? 'cursor-grabbing' : 'cursor-grab'
+        }`}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
+        onBlur={handlePointerUp}
+      >
+        <span aria-hidden className="text-lg leading-none">⋮⋮</span>
+        <span className="sr-only">Drag {label}</span>
+      </button>
+      <div className="pointer-events-auto">{children}</div>
+    </div>
+  );
+}
+
+function WorkspaceDropIndicator() {
+  return <div className="h-3 rounded-full border-2 border-dashed border-accent-400 bg-accent-100/40" />;
+}

--- a/web/src/modules/workspaceLayout/store.ts
+++ b/web/src/modules/workspaceLayout/store.ts
@@ -1,0 +1,206 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type WorkspaceColumnId = 'left' | 'center' | 'right';
+
+export type WorkspacePanelId =
+  | 'capture'
+  | 'cleanupInstructions'
+  | 'importEntries'
+  | 'snippets'
+  | 'transcriptHistory'
+  | 'transcript'
+  | 'summary'
+  | 'cleanupResult'
+  | 'actionItems'
+  | 'scheduleSuggestion'
+  | 'calendar'
+  | 'provider'
+  | 'scriptEditor'
+  | 'translationControls'
+  | 'generate'
+  | 'playback'
+  | 'batchQueue'
+  | 'pronunciation'
+  | 'ttsHistory'
+  | 'translationHistory'
+  | 'credentials'
+  | 'theme'
+  | 'compact'
+  | 'notifications';
+
+export type WorkspaceLayout = Record<WorkspaceColumnId, WorkspacePanelId[]>;
+
+const DEFAULT_LAYOUT: WorkspaceLayout = {
+  left: ['capture', 'cleanupInstructions', 'importEntries', 'snippets', 'transcriptHistory'],
+  center: ['transcript', 'summary', 'cleanupResult', 'actionItems', 'scheduleSuggestion', 'calendar'],
+  right: [
+    'provider',
+    'scriptEditor',
+    'translationControls',
+    'generate',
+    'playback',
+    'batchQueue',
+    'pronunciation',
+    'ttsHistory',
+    'translationHistory',
+    'credentials',
+    'theme',
+    'compact',
+    'notifications',
+  ],
+};
+
+const KNOWN_PANELS = new Set<WorkspacePanelId>(
+  Object.values(DEFAULT_LAYOUT).flat() as WorkspacePanelId[],
+);
+
+const isKnownPanel = (value: string): value is WorkspacePanelId => KNOWN_PANELS.has(value as WorkspacePanelId);
+
+const sanitizeLayout = (candidate?: Partial<Record<WorkspaceColumnId, WorkspacePanelId[]>>): WorkspaceLayout => {
+  const next: WorkspaceLayout = {
+    left: [],
+    center: [],
+    right: [],
+  };
+
+  const appended = new Set<WorkspacePanelId>();
+
+  const append = (panelId: WorkspacePanelId, columnId: WorkspaceColumnId) => {
+    if (appended.has(panelId)) {
+      return;
+    }
+    next[columnId].push(panelId);
+    appended.add(panelId);
+  };
+
+  if (candidate) {
+    (Object.keys(next) as WorkspaceColumnId[]).forEach((columnId) => {
+      const columnPanels = candidate[columnId];
+      if (!Array.isArray(columnPanels)) {
+        return;
+      }
+      columnPanels.forEach((panelId) => {
+        if (isKnownPanel(panelId)) {
+          append(panelId, columnId);
+        }
+      });
+    });
+  }
+
+  (Object.entries(DEFAULT_LAYOUT) as [WorkspaceColumnId, WorkspacePanelId[]][]).forEach(([columnId, panelIds]) => {
+    panelIds.forEach((panelId) => append(panelId, columnId));
+  });
+
+  return next;
+};
+
+interface WorkspaceLayoutState {
+  layout: WorkspaceLayout;
+  draggingPanelId: WorkspacePanelId | null;
+  actions: {
+    movePanel: (panelId: WorkspacePanelId, columnId: WorkspaceColumnId, targetIndex: number) => void;
+    removePanel: (panelId: WorkspacePanelId) => void;
+    reset: () => void;
+    startDragging: (panelId: WorkspacePanelId) => void;
+    stopDragging: () => void;
+    syncWithDefaults: () => void;
+  };
+}
+
+export const useWorkspaceLayoutStore = create<WorkspaceLayoutState>()(
+  persist(
+    (set, get) => ({
+      layout: sanitizeLayout(),
+      draggingPanelId: null,
+      actions: {
+        movePanel: (panelId, columnId, targetIndex) => {
+          set((state) => {
+            const nextLayout: WorkspaceLayout = {
+              left: [...state.layout.left],
+              center: [...state.layout.center],
+              right: [...state.layout.right],
+            };
+
+            (Object.keys(nextLayout) as WorkspaceColumnId[]).forEach((column) => {
+              const index = nextLayout[column].indexOf(panelId);
+              if (index >= 0) {
+                nextLayout[column].splice(index, 1);
+              }
+            });
+
+            const destination = nextLayout[columnId] ?? nextLayout.left;
+            const boundedIndex = Math.max(0, Math.min(targetIndex, destination.length));
+            destination.splice(boundedIndex, 0, panelId);
+
+            return { layout: nextLayout };
+          });
+        },
+        removePanel: (panelId) => {
+          set((state) => {
+            const nextLayout: WorkspaceLayout = {
+              left: state.layout.left.filter((id) => id !== panelId),
+              center: state.layout.center.filter((id) => id !== panelId),
+              right: state.layout.right.filter((id) => id !== panelId),
+            };
+            return { layout: sanitizeLayout(nextLayout) };
+          });
+        },
+        reset: () => set({ layout: sanitizeLayout(DEFAULT_LAYOUT) }),
+        startDragging: (panelId) => set({ draggingPanelId: panelId }),
+        stopDragging: () => set({ draggingPanelId: null }),
+        syncWithDefaults: () => {
+          set((state) => ({ layout: sanitizeLayout(state.layout) }));
+        },
+      },
+    }),
+    {
+      name: 'workspace-layout-v1',
+      version: 1,
+      migrate: (persistedState) => {
+        if (!persistedState || typeof persistedState !== 'object') {
+          return {
+            layout: sanitizeLayout(),
+            draggingPanelId: null,
+          };
+        }
+        const candidateLayout = (persistedState as { layout?: WorkspaceLayout }).layout;
+        return {
+          layout: sanitizeLayout(candidateLayout),
+          draggingPanelId: null,
+        };
+      },
+    },
+  ),
+);
+
+export const workspacePanelLabels: Record<WorkspacePanelId, string> = {
+  capture: 'Capture audio',
+  cleanupInstructions: 'Cleanup instructions',
+  importEntries: 'Imports',
+  snippets: 'Snippets',
+  transcriptHistory: 'Transcript history',
+  transcript: 'Transcript',
+  summary: 'Summary',
+  cleanupResult: 'Cleanup result',
+  actionItems: 'Action items',
+  scheduleSuggestion: 'Suggested calendar event',
+  calendar: 'Calendar follow-up',
+  provider: 'Provider and voice',
+  scriptEditor: 'Script editor',
+  translationControls: 'Translation settings',
+  generate: 'Generate speech',
+  playback: 'Playback',
+  batchQueue: 'Batch queue',
+  pronunciation: 'Pronunciation dictionary',
+  ttsHistory: 'Recent speech history',
+  translationHistory: 'Translation history',
+  credentials: 'Provider credentials',
+  theme: 'Theme preference',
+  compact: 'Compact layout',
+  notifications: 'Notifications',
+};
+
+export { DEFAULT_LAYOUT as workspaceDefaultLayout };

--- a/web/src/tests/components/TransitTranscriptionPanel.test.tsx
+++ b/web/src/tests/components/TransitTranscriptionPanel.test.tsx
@@ -58,11 +58,14 @@ describe('TransitTranscriptionPanel', () => {
     render(<TransitTranscriptionPanel />);
 
     expect(
-      await screen.findByText('Microphone recording is not supported in this browser. Use the upload option instead.'),
+      await screen.findByText('Recording is not supported in this browser. Upload audio files instead.'),
     ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText('Ready')).toBeInTheDocument();
     });
+
+    expect(screen.getByRole('button', { name: 'Drag Capture audio' })).toBeInTheDocument();
+    expect(document.querySelector('[data-workspace-column="left"]')).not.toBeNull();
   });
 });

--- a/web/src/tests/modules/workspaceLayout.test.ts
+++ b/web/src/tests/modules/workspaceLayout.test.ts
@@ -1,0 +1,54 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { act } from '@testing-library/react';
+import {
+  useWorkspaceLayoutStore,
+  workspaceDefaultLayout,
+  type WorkspaceLayout,
+} from '@/modules/workspaceLayout/store';
+
+const cloneLayout = (layout: WorkspaceLayout): WorkspaceLayout => ({
+  left: [...layout.left],
+  center: [...layout.center],
+  right: [...layout.right],
+});
+
+describe('workspace layout store', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('workspace-layout-v1');
+    act(() => {
+      useWorkspaceLayoutStore.setState(() => ({
+        layout: cloneLayout(workspaceDefaultLayout),
+        draggingPanelId: null,
+      }));
+    });
+  });
+
+  it('reorders a panel within the same column', () => {
+    const { actions } = useWorkspaceLayoutStore.getState();
+    act(() => {
+      actions.movePanel('cleanupInstructions', 'left', 0);
+    });
+    const layout = useWorkspaceLayoutStore.getState().layout;
+    expect(layout.left[0]).toBe('cleanupInstructions');
+  });
+
+  it('moves a panel across columns', () => {
+    const { actions } = useWorkspaceLayoutStore.getState();
+    act(() => {
+      actions.movePanel('transcript', 'left', 1);
+    });
+    const layout = useWorkspaceLayoutStore.getState().layout;
+    expect(layout.left.includes('transcript')).toBe(true);
+    expect(layout.center.includes('transcript')).toBe(false);
+  });
+
+  it('resets to the default layout', () => {
+    const { actions } = useWorkspaceLayoutStore.getState();
+    act(() => {
+      actions.movePanel('transcript', 'left', 0);
+      actions.reset();
+    });
+    const layout = useWorkspaceLayoutStore.getState().layout;
+    expect(layout).toEqual(cloneLayout(workspaceDefaultLayout));
+  });
+});


### PR DESCRIPTION
## Summary
- enable drag-and-drop panel layout with persistent storage
- refactor transit studio to render from draggable panel map
- add workspace layout tests and update panel render test

## Testing
- npm test
- npm run build