### PR TITLE
feat: add workspace layout persistence

### DIFF
--- a/Docs/workspace-layout-plan.md
+++ b/Docs/workspace-layout-plan.md
@@ -1,0 +1,35 @@
+# Workspace Layout Customisation Plan
+
+## Goals
+- Make every major workspace panel movable across the three-column layout in the web Transit workspace.
+- Persist each user’s preferred arrangement via the Convex backend so it loads automatically on sign-in.
+- Let users reset to the default layout without losing other workspace state.
+
+## Context
+- `TransitTranscriptionPanel.tsx` now renders columns from the persisted layout snapshot, with helper renderers for each `panelId`.
+- Panel content modules remain colocated with the Transit workspace but can be rearranged dynamically by the layout store.
+- The Convex deployment stores user layouts in the `workspace_layouts` table. A Next.js API route (`/api/workspace-layout`) mediates access so Convex credentials stay server-side, falling back to local storage when the service is unavailable.
+
+## Implementation Plan
+1. **Persisted layout model**
+   - Add a `workspace_layouts` table (`userId`, `layout`, `version`, `updatedAt`) to `convex/schema.ts`.
+   - Expose Convex functions (`getWorkspaceLayout`, `saveWorkspaceLayout`, `clearWorkspaceLayout`) in a new module.
+   - Represent layout as ordered columns of panel identifiers with a version number for forward compatibility.
+2. **Repository and Zustand store**
+   - ✅ The shared `WorkspaceLayoutRepository` abstraction supports Convex, API, local-storage, and noop implementations.
+   - ✅ `useWorkspaceLayoutStore` hydrates per-user layouts, tracks pending requests to handle account switching, persists moves, and exposes reset/error handling.
+   - ⏳ Consider debouncing drag-save operations if backend load becomes an issue; current implementation saves immediately after each drop.
+3. **UI refactor & drag-and-drop**
+   - ✅ Transit workspace renders movable panels using the persisted snapshot.
+   - ✅ Drag-and-drop uses native HTML APIs with keyboard-accessible drop zones.
+4. **Reset & persistence wiring**
+   - ✅ Layout hydrates when the active user changes; local cache prevents stale writes when switching accounts mid-request.
+   - ✅ A reset action clears both Convex and the local-cache fallback, restoring defaults.
+5. **Validation & docs**
+   - ✅ Vitest suites cover the API route (`workspaceLayoutRoute.test.ts`) and the store’s hydration behaviour (`workspaceLayoutStore.test.ts`).
+   - ✅ Documentation (this doc, README) references the server boundary and offline behaviour.
+   - ✅ `npm run test`, `npm run build`, and Convex codegen are part of the release checklist.
+
+## Open Questions
+- **Panel mobility:** All sections remain movable; revisit if UX research requests pinned “essential” panels.
+- **Layout versioning:** Monitor usage metrics to determine when to bump `CURRENT_WORKSPACE_LAYOUT_VERSION` and trigger migrations.

--- a/web/README.md
+++ b/web/README.md
@@ -6,6 +6,7 @@ The web workspace powers rapid iteration on the studio UI. It includes content i
 - Record live microphone sessions or upload audio, then watch transcripts stream in with summaries and action items.
 - Apply cleanup instructions (built-in presets like Australian English, professional tone, meeting minutes, or fully custom prompts) to generate polished copies alongside the raw transcript.
 - Persist transcripts, summaries, and cleanup results to Convex for authenticated users or encrypted IndexedDB for guests, with Google Calendar follow-ups available once OAuth is connected.
+- Arrange panels to suit your workflow. Layouts persist per-account through Convex (via `/api/workspace-layout`), with an automatic local-storage cache when Convex is unavailable. Switching accounts mid-session rehydrates the correct layout once the new user is authenticated.
 
 ## Authentication & Data Layer
 
@@ -30,6 +31,8 @@ Set the following environment variables before running the app:
 After changing `convex/schema.ts` run `npx convex dev` in `web/` to regenerate `_generated` types.
 
 Signed-in users have generation history, managed provisioning state, and pipeline definitions synchronised through Convex. Guests continue to rely on browser storage, falling back to encrypted IndexedDB for history/snippets and in-memory stores for provisioning/session data. When Convex is unavailable, pipelines gracefully fall back to JSON or in-memory storage.
+
+Workspace layout persistence follows the same pattern: Convex stores the canonical snapshot, while the client-side repository falls back to a local cache in offline or unauthorised states. Server-to-client traffic always flows through the Next.js route to keep Convex admin keys out of the browser bundle.
 
 ## Pipeline Automation
 

--- a/web/convex/_generated/api.d.ts
+++ b/web/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as session from "../session.js";
 import type * as transit from "../transit.js";
 import type * as translations from "../translations.js";
 import type * as users from "../users.js";
+import type * as workspaceLayouts from "../workspaceLayouts.js";
 
 import type {
   ApiFromModules,
@@ -42,6 +43,7 @@ declare const fullApi: ApiFromModules<{
   transit: typeof transit;
   translations: typeof translations;
   users: typeof users;
+  workspaceLayouts: typeof workspaceLayouts;
 }>;
 declare const fullApiWithMounts: typeof fullApi;
 

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -176,4 +176,19 @@ export default defineSchema({
     scope: v.array(v.string()),
     updatedAt: v.number(),
   }).index('by_user', ['userId']),
+
+  workspace_layouts: defineTable({
+    userId: v.string(),
+    layout: v.object({
+      version: v.number(),
+      columns: v.array(
+        v.object({
+          id: v.string(),
+          panels: v.array(v.string()),
+        }),
+      ),
+    }),
+    version: v.number(),
+    updatedAt: v.number(),
+  }).index('by_user', ['userId']),
 });

--- a/web/convex/workspaceLayouts.ts
+++ b/web/convex/workspaceLayouts.ts
@@ -1,0 +1,89 @@
+import { mutation, query, type MutationCtx, type QueryCtx } from './_generated/server';
+import { v } from 'convex/values';
+import type { Doc } from './_generated/dataModel';
+
+type WorkspaceLayoutDoc = Doc<'workspace_layouts'>;
+
+const columnSchema = v.object({
+  id: v.string(),
+  panels: v.array(v.string()),
+});
+
+const layoutSchema = v.object({
+  version: v.number(),
+  columns: v.array(columnSchema),
+});
+
+const mapDoc = (doc: WorkspaceLayoutDoc) => ({
+  userId: doc.userId,
+  layout: doc.layout,
+  version: doc.version,
+  updatedAt: doc.updatedAt,
+});
+
+const findByUserId = async (ctx: QueryCtx | MutationCtx, userId: string) => {
+  return await ctx.db
+    .query('workspace_layouts')
+    .withIndex('by_user', (q) => q.eq('userId', userId))
+    .first();
+};
+
+export const getWorkspaceLayout = query({
+  args: {
+    userId: v.string(),
+  },
+  handler: async (ctx, { userId }) => {
+    const existing = await findByUserId(ctx, userId);
+    if (!existing) {
+      return null;
+    }
+    return mapDoc(existing);
+  },
+});
+
+export const saveWorkspaceLayout = mutation({
+  args: {
+    payload: v.object({
+      userId: v.string(),
+      layout: layoutSchema,
+    }),
+  },
+  handler: async (ctx, { payload }) => {
+    const { userId, layout } = payload;
+    const now = Date.now();
+    const existing = await findByUserId(ctx, userId);
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        layout,
+        version: layout.version,
+        updatedAt: now,
+      });
+      const updated = await ctx.db.get(existing._id);
+      return { layout: updated ? mapDoc(updated) : null };
+    }
+
+    await ctx.db.insert('workspace_layouts', {
+      userId,
+      layout,
+      version: layout.version,
+      updatedAt: now,
+    });
+
+    const inserted = await findByUserId(ctx, userId);
+    return { layout: inserted ? mapDoc(inserted) : null };
+  },
+});
+
+export const clearWorkspaceLayout = mutation({
+  args: {
+    userId: v.string(),
+  },
+  handler: async (ctx, { userId }) => {
+    const existing = await findByUserId(ctx, userId);
+    if (!existing) {
+      return { cleared: false };
+    }
+    await ctx.db.delete(existing._id);
+    return { cleared: true };
+  },
+});

--- a/web/src/app/api/workspace-layout/context.ts
+++ b/web/src/app/api/workspace-layout/context.ts
@@ -1,0 +1,51 @@
+import { resolveConvexAuthConfig } from '@/lib/convexAuth';
+import type { WorkspaceLayoutRepository } from '@/lib/workspaceLayout/repository';
+import { NoopWorkspaceLayoutRepository } from '@/lib/workspaceLayout/repository';
+import { ConvexWorkspaceLayoutRepository } from '@/lib/workspaceLayout/repository.server';
+
+type WorkspaceLayoutRepositoryKind = 'convex' | 'noop';
+
+let repository: WorkspaceLayoutRepository | null = null;
+let repositoryKind: WorkspaceLayoutRepositoryKind | null = null;
+
+function createRepository(): WorkspaceLayoutRepository {
+  if (repository) {
+    return repository;
+  }
+
+  const convexUrl = process.env.CONVEX_URL?.trim();
+  const auth = resolveConvexAuthConfig();
+
+  if (convexUrl && auth) {
+    try {
+      repository = new ConvexWorkspaceLayoutRepository({
+        baseUrl: convexUrl,
+        authToken: auth.token,
+        authScheme: auth.scheme,
+      });
+      repositoryKind = 'convex';
+      return repository;
+    } catch (error) {
+      console.warn('Failed to initialise Convex workspace layout repository, falling back to noop store:', error);
+    }
+  }
+
+  repository = new NoopWorkspaceLayoutRepository();
+  repositoryKind = 'noop';
+  return repository;
+}
+
+export function getWorkspaceLayoutRepository(): WorkspaceLayoutRepository {
+  return createRepository();
+}
+
+export function getWorkspaceLayoutRepositoryKind(): WorkspaceLayoutRepositoryKind | null {
+  return repositoryKind;
+}
+
+export function resetWorkspaceLayoutRepositoryForTesting(): void {
+  repository = null;
+  repositoryKind = null;
+}
+
+export type { WorkspaceLayoutRepositoryKind };

--- a/web/src/app/api/workspace-layout/route.ts
+++ b/web/src/app/api/workspace-layout/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { resolveRequestIdentity } from '@/lib/auth/identity';
+import { parseWorkspaceLayoutSnapshot, serializeWorkspaceLayoutSnapshot } from '@/lib/workspaceLayout/repository';
+import {
+  getWorkspaceLayoutRepository,
+  getWorkspaceLayoutRepositoryKind,
+} from './context';
+
+function unauthorizedResponse() {
+  return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+}
+
+function forbiddenResponse() {
+  return NextResponse.json({ error: 'Not authorised to access workspace layout' }, { status: 403 });
+}
+
+function unavailableResponse() {
+  return NextResponse.json({ error: 'Workspace layout service unavailable' }, { status: 503 });
+}
+
+function normalizeUserId(candidate: unknown): string | null {
+  if (typeof candidate !== 'string') {
+    return null;
+  }
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function GET(request: Request) {
+  const identity = resolveRequestIdentity(request);
+  if (!identity.userId) {
+    return unauthorizedResponse();
+  }
+
+  const repository = getWorkspaceLayoutRepository();
+  const kind = getWorkspaceLayoutRepositoryKind();
+  if (kind !== 'convex') {
+    return unavailableResponse();
+  }
+
+  const url = new URL(request.url);
+  const requestedUserId = normalizeUserId(url.searchParams.get('userId')) ?? identity.userId;
+  if (requestedUserId !== identity.userId) {
+    return forbiddenResponse();
+  }
+
+  try {
+    const layout = await repository.load(identity.userId);
+    return NextResponse.json({ layout: layout ? serializeWorkspaceLayoutSnapshot(layout) : null });
+  } catch (error) {
+    console.error('Failed to load workspace layout', error);
+    return NextResponse.json({ error: 'Unable to load workspace layout' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const identity = resolveRequestIdentity(request);
+  if (!identity.userId) {
+    return unauthorizedResponse();
+  }
+
+  const repository = getWorkspaceLayoutRepository();
+  const kind = getWorkspaceLayoutRepositoryKind();
+  if (kind !== 'convex') {
+    return unavailableResponse();
+  }
+
+  let payload: { layout?: unknown; userId?: unknown };
+  try {
+    payload = (await request.json()) as { layout?: unknown; userId?: unknown };
+  } catch {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const targetUserId = normalizeUserId(payload.userId) ?? identity.userId;
+  if (targetUserId !== identity.userId) {
+    return forbiddenResponse();
+  }
+
+  const layout = parseWorkspaceLayoutSnapshot(payload.layout);
+  if (!layout) {
+    return NextResponse.json({ error: 'Invalid workspace layout' }, { status: 400 });
+  }
+
+  try {
+    await repository.save(identity.userId, layout);
+    return NextResponse.json({ layout: serializeWorkspaceLayoutSnapshot(layout) });
+  } catch (error) {
+    console.error('Failed to save workspace layout', error);
+    return NextResponse.json({ error: 'Unable to save workspace layout' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const identity = resolveRequestIdentity(request);
+  if (!identity.userId) {
+    return unauthorizedResponse();
+  }
+
+  const repository = getWorkspaceLayoutRepository();
+  const kind = getWorkspaceLayoutRepositoryKind();
+  if (kind !== 'convex') {
+    return unavailableResponse();
+  }
+
+  const url = new URL(request.url);
+  const requestedUserId = normalizeUserId(url.searchParams.get('userId')) ?? identity.userId;
+  if (requestedUserId !== identity.userId) {
+    return forbiddenResponse();
+  }
+
+  try {
+    await repository.clear(identity.userId);
+    return NextResponse.json({ cleared: true });
+  } catch (error) {
+    console.error('Failed to clear workspace layout', error);
+    return NextResponse.json({ error: 'Unable to clear workspace layout' }, { status: 500 });
+  }
+}

--- a/web/src/lib/workspaceLayout/repository.server.ts
+++ b/web/src/lib/workspaceLayout/repository.server.ts
@@ -1,0 +1,54 @@
+import { fetchMutation, fetchQuery, type NextjsOptions } from 'convex/nextjs';
+import { api } from '../../../convex/_generated/api';
+import { buildConvexClientOptions } from '../convex/client';
+import type { WorkspaceLayoutSnapshot } from '@/modules/workspaceLayout/types';
+import {
+  parseWorkspaceLayoutSnapshot,
+  serializeWorkspaceLayoutSnapshot,
+  type WorkspaceLayoutRepository,
+} from './repository';
+
+interface ConvexWorkspaceLayoutRepositoryOptions {
+  baseUrl: string;
+  authToken: string;
+  authScheme?: string;
+}
+
+export class ConvexWorkspaceLayoutRepository implements WorkspaceLayoutRepository {
+  private readonly clientOptions: NextjsOptions;
+
+  constructor(options: ConvexWorkspaceLayoutRepositoryOptions) {
+    this.clientOptions = buildConvexClientOptions({
+      baseUrl: options.baseUrl,
+      authToken: options.authToken,
+      authScheme: options.authScheme,
+    });
+  }
+
+  async load(userId: string): Promise<WorkspaceLayoutSnapshot | null> {
+    const result = await fetchQuery(api.workspaceLayouts.getWorkspaceLayout, { userId }, this.clientOptions);
+    if (!result) {
+      return null;
+    }
+
+    const layout = parseWorkspaceLayoutSnapshot(result.layout);
+    return layout;
+  }
+
+  async save(userId: string, layout: WorkspaceLayoutSnapshot): Promise<void> {
+    await fetchMutation(
+      api.workspaceLayouts.saveWorkspaceLayout,
+      {
+        payload: {
+          userId,
+          layout: serializeWorkspaceLayoutSnapshot(layout),
+        },
+      },
+      this.clientOptions,
+    );
+  }
+
+  async clear(userId: string): Promise<void> {
+    await fetchMutation(api.workspaceLayouts.clearWorkspaceLayout, { userId }, this.clientOptions);
+  }
+}

--- a/web/src/lib/workspaceLayout/repository.ts
+++ b/web/src/lib/workspaceLayout/repository.ts
@@ -1,0 +1,352 @@
+import type { WorkspaceLayoutColumn, WorkspaceLayoutSnapshot } from '@/modules/workspaceLayout/types';
+
+export interface WorkspaceLayoutRepository {
+  load(userId: string): Promise<WorkspaceLayoutSnapshot | null>;
+  save(userId: string, layout: WorkspaceLayoutSnapshot): Promise<void>;
+  clear(userId: string): Promise<void>;
+}
+
+export type RawWorkspaceLayoutColumn = {
+  id: string;
+  panels?: string[];
+  panelIds?: string[];
+};
+
+export type RawWorkspaceLayout = {
+  version: number;
+  columns: RawWorkspaceLayoutColumn[];
+};
+
+type ConvexWorkspaceLayoutPayload = {
+  version: number;
+  columns: {
+    id: string;
+    panels: string[];
+  }[];
+};
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+export function parseWorkspaceLayoutSnapshot(layout: unknown): WorkspaceLayoutSnapshot | null {
+  if (!layout || typeof layout !== 'object') {
+    return null;
+  }
+
+  const { version, columns } = layout as Partial<RawWorkspaceLayout>;
+  if (typeof version !== 'number' || !Array.isArray(columns)) {
+    return null;
+  }
+
+  const normalizedColumns: WorkspaceLayoutColumn[] = [];
+
+  for (const column of columns) {
+    if (!column || typeof column !== 'object') {
+      return null;
+    }
+
+    const { id, panelIds, panels } = column as RawWorkspaceLayoutColumn;
+    const nextPanelIds = panelIds ?? panels;
+
+    if (typeof id !== 'string' || !isStringArray(nextPanelIds)) {
+      return null;
+    }
+
+    normalizedColumns.push({
+      id: id as WorkspaceLayoutColumn['id'],
+      panelIds: nextPanelIds as WorkspaceLayoutColumn['panelIds'],
+    });
+  }
+
+  return {
+    version,
+    columns: normalizedColumns,
+  };
+}
+
+export function serializeWorkspaceLayoutSnapshot(layout: WorkspaceLayoutSnapshot): ConvexWorkspaceLayoutPayload {
+  return {
+    version: layout.version,
+    columns: layout.columns.map(({ id, panelIds }) => ({
+      id,
+      panels: [...panelIds],
+    })),
+  };
+}
+
+export class ApiWorkspaceLayoutRepository implements WorkspaceLayoutRepository {
+  private offlineMode = false;
+
+  constructor(private readonly fallback: WorkspaceLayoutRepository | null = null) {}
+
+  private createError(message: string, allowFallback: boolean): Error & { allowFallback: boolean } {
+    const error = new Error(message) as Error & { allowFallback: boolean };
+    error.allowFallback = allowFallback;
+    return error;
+  }
+
+  private shouldFallback(error: unknown): boolean {
+    if (!this.fallback) {
+      return false;
+    }
+
+    const candidate = error as { allowFallback?: boolean } | null;
+    if (candidate && candidate.allowFallback === false) {
+      return false;
+    }
+    return true;
+  }
+
+  private buildUrl(userId: string | null | undefined): string {
+    const normalized = userId?.trim();
+    if (!normalized) {
+      return '/api/workspace-layout';
+    }
+    const params = new URLSearchParams({ userId: normalized });
+    return `/api/workspace-layout?${params.toString()}`;
+  }
+
+  private async request(input: RequestInfo, init: RequestInit): Promise<Response> {
+    if (typeof fetch !== 'function') {
+      throw new Error('Fetch API is not available in this environment.');
+    }
+
+    return await fetch(input, {
+      credentials: 'include',
+      cache: 'no-store',
+      ...init,
+    });
+  }
+
+  async load(userId: string): Promise<WorkspaceLayoutSnapshot | null> {
+    if (this.offlineMode && this.fallback) {
+      return this.fallback.load(userId);
+    }
+
+    try {
+      const response = await this.request(this.buildUrl(userId), { method: 'GET' });
+
+      if (response.status === 204 || response.status === 404) {
+        if (this.fallback) {
+          await this.fallback.clear(userId);
+        }
+        return null;
+      }
+
+      if (response.status === 401 || response.status === 403) {
+        if (this.fallback) {
+          await this.fallback.clear(userId);
+        }
+        return null;
+      }
+
+      if (response.status === 503 && this.fallback) {
+        this.offlineMode = true;
+        return this.fallback.load(userId);
+      }
+
+      if (response.status >= 500 && this.fallback) {
+        this.offlineMode = true;
+        return this.fallback.load(userId);
+      }
+
+      if (!response.ok) {
+        throw this.createError(`Failed to load workspace layout (status ${response.status})`, false);
+      }
+
+      const payload = (await response.json()) as { layout?: unknown };
+      const layout = parseWorkspaceLayoutSnapshot(payload.layout ?? null);
+      if (!layout) {
+        return null;
+      }
+
+      if (this.fallback) {
+        await this.fallback.save(userId, layout);
+      }
+
+      return layout;
+    } catch (error) {
+      if (this.shouldFallback(error) && this.fallback) {
+        this.offlineMode = true;
+        return this.fallback.load(userId);
+      }
+      throw error;
+    }
+  }
+
+  async save(userId: string, layout: WorkspaceLayoutSnapshot): Promise<void> {
+    if (this.offlineMode && this.fallback) {
+      await this.fallback.save(userId, layout);
+      return;
+    }
+
+    try {
+      const response = await this.request('/api/workspace-layout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ userId, layout }),
+      });
+
+      if (response.status === 503 && this.fallback) {
+        this.offlineMode = true;
+        await this.fallback.save(userId, layout);
+        return;
+      }
+
+      if (response.status >= 500 && this.fallback) {
+        this.offlineMode = true;
+        await this.fallback.save(userId, layout);
+        return;
+      }
+
+      if (response.status === 401 || response.status === 403) {
+        throw this.createError(`Failed to save workspace layout (status ${response.status})`, false);
+      }
+
+      if (!response.ok) {
+        throw this.createError(`Failed to save workspace layout (status ${response.status})`, false);
+      }
+
+      if (this.fallback) {
+        await this.fallback.save(userId, layout);
+      }
+    } catch (error) {
+      if (this.shouldFallback(error) && this.fallback) {
+        this.offlineMode = true;
+        await this.fallback.save(userId, layout);
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async clear(userId: string): Promise<void> {
+    if (this.offlineMode && this.fallback) {
+      await this.fallback.clear(userId);
+      return;
+    }
+
+    try {
+      const response = await this.request(this.buildUrl(userId), { method: 'DELETE' });
+
+      if (response.status === 503 && this.fallback) {
+        this.offlineMode = true;
+        await this.fallback.clear(userId);
+        return;
+      }
+
+      if (response.status >= 500 && this.fallback) {
+        this.offlineMode = true;
+        await this.fallback.clear(userId);
+        return;
+      }
+
+      if (response.status === 401 || response.status === 403) {
+        throw this.createError(`Failed to clear workspace layout (status ${response.status})`, false);
+      }
+
+      if (!response.ok && response.status !== 404) {
+        throw this.createError(`Failed to clear workspace layout (status ${response.status})`, false);
+      }
+
+      if (this.fallback) {
+        await this.fallback.clear(userId);
+      }
+    } catch (error) {
+      if (this.shouldFallback(error) && this.fallback) {
+        this.offlineMode = true;
+        await this.fallback.clear(userId);
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+export class LocalWorkspaceLayoutRepository implements WorkspaceLayoutRepository {
+  private storageAvailable(): boolean {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return false;
+    }
+    try {
+      const key = '__workspace_layout_test__';
+      window.localStorage.setItem(key, '1');
+      window.localStorage.removeItem(key);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private key(userId: string): string {
+    return `workspace-layout:${userId}`;
+  }
+
+  async load(userId: string): Promise<WorkspaceLayoutSnapshot | null> {
+    if (!this.storageAvailable()) {
+      return null;
+    }
+    try {
+      const raw = window.localStorage.getItem(this.key(userId));
+      if (!raw) {
+        return null;
+      }
+      const parsed = parseWorkspaceLayoutSnapshot(JSON.parse(raw));
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  async save(userId: string, layout: WorkspaceLayoutSnapshot): Promise<void> {
+    if (!this.storageAvailable()) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(this.key(userId), JSON.stringify(layout));
+    } catch {
+      // Ignore write errors; layout is a convenience cache in this mode.
+    }
+  }
+
+  async clear(userId: string): Promise<void> {
+    if (!this.storageAvailable()) {
+      return;
+    }
+    try {
+      window.localStorage.removeItem(this.key(userId));
+    } catch {
+      // Ignore.
+    }
+  }
+}
+
+export class NoopWorkspaceLayoutRepository implements WorkspaceLayoutRepository {
+  async load(): Promise<WorkspaceLayoutSnapshot | null> {
+    return null;
+  }
+
+  async save(): Promise<void> {}
+
+  async clear(): Promise<void> {}
+}
+
+let repository: WorkspaceLayoutRepository | null = null;
+
+export function getWorkspaceLayoutRepository(): WorkspaceLayoutRepository {
+  if (repository) {
+    return repository;
+  }
+
+  if (typeof window !== 'undefined') {
+    const fallback = new LocalWorkspaceLayoutRepository();
+    repository = new ApiWorkspaceLayoutRepository(fallback);
+    return repository;
+  }
+
+  repository = new NoopWorkspaceLayoutRepository();
+  return repository;
+}

--- a/web/src/modules/workspaceLayout/store.ts
+++ b/web/src/modules/workspaceLayout/store.ts
@@ -1,0 +1,234 @@
+'use client';
+
+import { create } from 'zustand';
+import {
+  ALL_WORKSPACE_PANEL_IDS,
+  CURRENT_WORKSPACE_LAYOUT_VERSION,
+  DEFAULT_WORKSPACE_LAYOUT,
+  type WorkspaceColumnId,
+  type WorkspaceLayoutSnapshot,
+  type WorkspacePanelId,
+} from './types';
+import { getWorkspaceLayoutRepository } from '@/lib/workspaceLayout/repository';
+
+interface WorkspaceLayoutState {
+  layout: WorkspaceLayoutSnapshot;
+  hydratedForUserId?: string;
+  pendingUserId?: string;
+  hydrationRequestId?: number;
+  isHydrating: boolean;
+  isSaving: boolean;
+  error?: string;
+  actions: {
+    hydrate: (userId: string | null | undefined) => Promise<void>;
+    movePanel: (panelId: WorkspacePanelId, targetColumnId: WorkspaceColumnId, targetIndex: number) => void;
+    reset: () => Promise<void>;
+    setError: (message: string | undefined) => void;
+  };
+}
+
+const repository = getWorkspaceLayoutRepository();
+
+let hydrationRequestCounter = 0;
+
+const defaultColumnForPanel = (() => {
+  const lookup = new Map<WorkspacePanelId, WorkspaceColumnId>();
+  DEFAULT_WORKSPACE_LAYOUT.columns.forEach((column) => {
+    column.panelIds.forEach((panelId) => lookup.set(panelId, column.id));
+  });
+  return lookup;
+})();
+
+function cloneLayout(layout: WorkspaceLayoutSnapshot): WorkspaceLayoutSnapshot {
+  return JSON.parse(JSON.stringify(layout)) as WorkspaceLayoutSnapshot;
+}
+
+function normaliseLayout(source: WorkspaceLayoutSnapshot | null | undefined): WorkspaceLayoutSnapshot {
+  if (!source || source.version !== CURRENT_WORKSPACE_LAYOUT_VERSION) {
+    return cloneLayout(DEFAULT_WORKSPACE_LAYOUT);
+  }
+
+  const seen = new Set<WorkspacePanelId>();
+  const columnMap = new Map<WorkspaceColumnId, WorkspacePanelId[]>();
+
+  DEFAULT_WORKSPACE_LAYOUT.columns.forEach((column) => {
+    columnMap.set(column.id, []);
+  });
+
+  source.columns.forEach((column) => {
+    if (!columnMap.has(column.id as WorkspaceColumnId)) {
+      return;
+    }
+    const nextPanels: WorkspacePanelId[] = [];
+    column.panelIds.forEach((panelId) => {
+      if (!ALL_WORKSPACE_PANEL_IDS.includes(panelId) || seen.has(panelId)) {
+        return;
+      }
+      nextPanels.push(panelId);
+      seen.add(panelId);
+    });
+    columnMap.set(column.id as WorkspaceColumnId, nextPanels);
+  });
+
+  const missing = ALL_WORKSPACE_PANEL_IDS.filter((panelId) => !seen.has(panelId));
+  missing.forEach((panelId) => {
+    const fallbackColumn = defaultColumnForPanel.get(panelId) ?? 'right';
+    const target = columnMap.get(fallbackColumn) ?? [];
+    target.push(panelId);
+    columnMap.set(fallbackColumn, target);
+  });
+
+  return {
+    version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+    columns: DEFAULT_WORKSPACE_LAYOUT.columns.map((column) => ({
+      id: column.id,
+      panelIds: columnMap.get(column.id) ?? [],
+    })),
+  };
+}
+
+async function persistLayout(userId: string | undefined, layout: WorkspaceLayoutSnapshot, set: (partial: Partial<WorkspaceLayoutState>) => void) {
+  if (!userId) {
+    return;
+  }
+  set({ isSaving: true, error: undefined });
+  try {
+    await repository.save(userId, layout);
+  } catch (error) {
+    console.error('Failed to save workspace layout', error);
+    set({ error: 'Unable to save layout right now.' });
+  } finally {
+    set({ isSaving: false });
+  }
+}
+
+export const useWorkspaceLayoutStore = create<WorkspaceLayoutState>((set, get) => ({
+  layout: cloneLayout(DEFAULT_WORKSPACE_LAYOUT),
+  hydratedForUserId: undefined,
+  pendingUserId: undefined,
+  hydrationRequestId: undefined,
+  isHydrating: false,
+  isSaving: false,
+  error: undefined,
+  actions: {
+    hydrate: async (userId) => {
+      const normalized = userId?.trim();
+      if (!normalized) {
+        set({
+          layout: cloneLayout(DEFAULT_WORKSPACE_LAYOUT),
+          hydratedForUserId: undefined,
+          pendingUserId: undefined,
+          hydrationRequestId: undefined,
+          isHydrating: false,
+          error: undefined,
+        });
+        return;
+      }
+
+      const state = get();
+      if (!state.isHydrating && state.hydratedForUserId === normalized) {
+        return;
+      }
+      if (state.isHydrating && state.pendingUserId === normalized) {
+        return;
+      }
+
+      const requestId = ++hydrationRequestCounter;
+      set({
+        isHydrating: true,
+        error: undefined,
+        pendingUserId: normalized,
+        hydrationRequestId: requestId,
+      });
+      try {
+        const remoteLayout = await repository.load(normalized);
+        const layout = normaliseLayout(remoteLayout);
+        const current = get();
+        if (current.hydrationRequestId !== requestId || current.pendingUserId !== normalized) {
+          return;
+        }
+        set({
+          layout,
+          hydratedForUserId: normalized,
+          error: undefined,
+        });
+      } catch (error) {
+        console.error('Failed to hydrate workspace layout', error);
+        const current = get();
+        if (current.hydrationRequestId !== requestId || current.pendingUserId !== normalized) {
+          return;
+        }
+        set({
+          layout: cloneLayout(DEFAULT_WORKSPACE_LAYOUT),
+          hydratedForUserId: normalized,
+          error: 'Workspace layout could not be loaded. Using default arrangement.',
+        });
+      } finally {
+        const current = get();
+        if (current.hydrationRequestId === requestId) {
+          set({
+            isHydrating: false,
+            pendingUserId: undefined,
+            hydrationRequestId: undefined,
+          });
+        }
+      }
+    },
+    movePanel: (panelId, targetColumnId, targetIndex) => {
+      const state = get();
+      const { layout } = state;
+      const sourceColumn = layout.columns.find((column) => column.panelIds.includes(panelId));
+      const sourceColumnId = sourceColumn?.id;
+      const sourceIndex = sourceColumn ? sourceColumn.panelIds.indexOf(panelId) : -1;
+      const columns = layout.columns.map((column) => ({
+        ...column,
+        panelIds: column.panelIds.filter((id) => id !== panelId),
+      }));
+      const targetColumn = columns.find((column) => column.id === targetColumnId);
+      if (!targetColumn) {
+        return;
+      }
+      let desiredIndex = Math.max(0, Math.min(targetColumn.panelIds.length, targetIndex));
+      if (sourceColumnId === targetColumnId && sourceIndex >= 0 && targetIndex > sourceIndex) {
+        desiredIndex = Math.max(0, Math.min(targetColumn.panelIds.length, targetIndex - 1));
+      }
+      if (sourceColumnId === targetColumnId && sourceIndex === desiredIndex) {
+        return;
+      }
+      targetColumn.panelIds = [
+        ...targetColumn.panelIds.slice(0, desiredIndex),
+        panelId,
+        ...targetColumn.panelIds.slice(desiredIndex),
+      ];
+      const nextLayout: WorkspaceLayoutSnapshot = {
+        version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+        columns,
+      };
+      set({ layout: nextLayout });
+      void persistLayout(get().hydratedForUserId, nextLayout, set);
+    },
+    reset: async () => {
+      const state = get();
+      const userId = state.hydratedForUserId;
+      const nextLayout = cloneLayout(DEFAULT_WORKSPACE_LAYOUT);
+      set({ layout: nextLayout, error: undefined });
+      if (!userId) {
+        return;
+      }
+      set({ isSaving: true });
+      try {
+        await repository.clear(userId);
+      } catch (error) {
+        console.error('Failed to clear workspace layout', error);
+        set({
+          error: 'Could not reset layout on the server.',
+        });
+      } finally {
+        set({ isSaving: false });
+      }
+    },
+    setError: (message) => {
+      set({ error: message });
+    },
+  },
+}));

--- a/web/src/modules/workspaceLayout/types.ts
+++ b/web/src/modules/workspaceLayout/types.ts
@@ -1,0 +1,70 @@
+'use client';
+
+export type WorkspaceColumnId = 'full' | 'left' | 'center' | 'right';
+
+export type WorkspacePanelId =
+  | 'pipelineStatus'
+  | 'captureAudio'
+  | 'uploadAudio'
+  | 'cleanupInstructions'
+  | 'importPanel'
+  | 'snippetPanel'
+  | 'transcriptHistory'
+  | 'transcriptView'
+  | 'summary'
+  | 'cleanupResult'
+  | 'actionItems'
+  | 'suggestedCalendarEvent'
+  | 'calendarFollowUp'
+  | 'ttsControls';
+
+export interface WorkspaceLayoutColumn {
+  id: WorkspaceColumnId;
+  panelIds: WorkspacePanelId[];
+}
+
+export interface WorkspaceLayoutSnapshot {
+  version: number;
+  columns: WorkspaceLayoutColumn[];
+}
+
+export const CURRENT_WORKSPACE_LAYOUT_VERSION = 2;
+
+export const ALL_WORKSPACE_PANEL_IDS: WorkspacePanelId[] = [
+  'pipelineStatus',
+  'captureAudio',
+  'uploadAudio',
+  'cleanupInstructions',
+  'importPanel',
+  'snippetPanel',
+  'transcriptHistory',
+  'transcriptView',
+  'summary',
+  'cleanupResult',
+  'actionItems',
+  'suggestedCalendarEvent',
+  'calendarFollowUp',
+  'ttsControls',
+];
+
+export const DEFAULT_WORKSPACE_LAYOUT: WorkspaceLayoutSnapshot = {
+  version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+  columns: [
+    {
+      id: 'full',
+      panelIds: ['pipelineStatus'],
+    },
+    {
+      id: 'left',
+      panelIds: ['captureAudio', 'uploadAudio', 'cleanupInstructions', 'importPanel', 'snippetPanel', 'transcriptHistory'],
+    },
+    {
+      id: 'center',
+      panelIds: ['transcriptView', 'summary', 'cleanupResult', 'actionItems', 'suggestedCalendarEvent', 'calendarFollowUp'],
+    },
+    {
+      id: 'right',
+      panelIds: ['ttsControls'],
+    },
+  ],
+};

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,5 +1,5 @@
-@import 'tailwindcss';
 @config '../../tailwind.config.ts';
+@import 'tailwindcss';
 
 :root {
   --color-scheme: light;

--- a/web/src/tests/unit/api/workspaceLayoutRoute.test.ts
+++ b/web/src/tests/unit/api/workspaceLayoutRoute.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET, POST, DELETE } from '@/app/api/workspace-layout/route';
+import type { WorkspaceLayoutSnapshot } from '@/modules/workspaceLayout/types';
+import { __setMockServerAuthState } from '@/tests/mocks/clerkNextjsServerMock';
+
+type MockKind = 'convex' | 'noop';
+
+const mockRepository = {
+  load: vi.fn<[string], Promise<WorkspaceLayoutSnapshot | null>>(),
+  save: vi.fn<[string, WorkspaceLayoutSnapshot], Promise<void>>(),
+  clear: vi.fn<[string], Promise<void>>(),
+};
+
+let mockKind: MockKind = 'convex';
+
+vi.mock('@/app/api/workspace-layout/context', () => ({
+  getWorkspaceLayoutRepository: () => mockRepository,
+  getWorkspaceLayoutRepositoryKind: () => mockKind,
+}));
+
+describe('workspace layout route', () => {
+  beforeEach(() => {
+    mockKind = 'convex';
+    __setMockServerAuthState({ userId: null });
+    mockRepository.load.mockReset();
+    mockRepository.save.mockReset();
+    mockRepository.clear.mockReset();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const response = await GET(new Request('https://example.com/api/workspace-layout'));
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 503 when Convex repository is unavailable', async () => {
+    mockKind = 'noop';
+    __setMockServerAuthState({ userId: 'user_1' });
+
+    const response = await GET(new Request('https://example.com/api/workspace-layout'));
+    expect(response.status).toBe(503);
+    expect(mockRepository.load).not.toHaveBeenCalled();
+  });
+
+  it('loads workspace layout for authenticated users', async () => {
+    __setMockServerAuthState({ userId: 'user_2' });
+    const snapshot: WorkspaceLayoutSnapshot = {
+      version: 2,
+      columns: [
+        { id: 'left', panelIds: ['pipelineStatus'] },
+        { id: 'right', panelIds: ['ttsControls'] },
+      ],
+    };
+    mockRepository.load.mockResolvedValue(snapshot);
+
+    const response = await GET(new Request('https://example.com/api/workspace-layout'));
+    expect(response.status).toBe(200);
+    expect(mockRepository.load).toHaveBeenCalledWith('user_2');
+
+    const payload = (await response.json()) as { layout: { columns: Array<{ id: string; panels: string[] }> } };
+    expect(payload.layout.columns[0].panels).toEqual(['pipelineStatus']);
+    expect(payload.layout.columns[1].panels).toEqual(['ttsControls']);
+  });
+
+  it('rejects save requests with mismatched user ids', async () => {
+    __setMockServerAuthState({ userId: 'user_3' });
+
+    const response = await POST(
+      new Request('https://example.com/api/workspace-layout', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user_4',
+          layout: {
+            version: 2,
+            columns: [],
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid layout payloads', async () => {
+    __setMockServerAuthState({ userId: 'user_5' });
+
+    const response = await POST(
+      new Request('https://example.com/api/workspace-layout', {
+        method: 'POST',
+        body: JSON.stringify({
+          layout: {
+            version: '2',
+            columns: [],
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('saves workspace layout payloads for authenticated users', async () => {
+    __setMockServerAuthState({ userId: 'user_6' });
+    mockRepository.save.mockResolvedValue();
+
+    const response = await POST(
+      new Request('https://example.com/api/workspace-layout', {
+        method: 'POST',
+        body: JSON.stringify({
+          layout: {
+            version: 2,
+            columns: [
+              { id: 'left', panels: ['pipelineStatus'] },
+              { id: 'right', panels: ['ttsControls'] },
+            ],
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRepository.save).toHaveBeenCalledWith('user_6', {
+      version: 2,
+      columns: [
+        { id: 'left', panelIds: ['pipelineStatus'] },
+        { id: 'right', panelIds: ['ttsControls'] },
+      ],
+    });
+  });
+
+  it('clears workspace layout when requested by owner', async () => {
+    __setMockServerAuthState({ userId: 'user_7' });
+    mockRepository.clear.mockResolvedValue();
+
+    const response = await DELETE(new Request('https://example.com/api/workspace-layout', { method: 'DELETE' }));
+
+    expect(response.status).toBe(200);
+    expect(mockRepository.clear).toHaveBeenCalledWith('user_7');
+  });
+});

--- a/web/src/tests/unit/workspaceLayoutStore.test.ts
+++ b/web/src/tests/unit/workspaceLayoutStore.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CURRENT_WORKSPACE_LAYOUT_VERSION,
+  DEFAULT_WORKSPACE_LAYOUT,
+  type WorkspaceLayoutSnapshot,
+} from '@/modules/workspaceLayout/types';
+
+vi.mock('@/lib/workspaceLayout/repository', () => {
+  const repository = {
+    load: vi.fn<[string], Promise<WorkspaceLayoutSnapshot | null>>(),
+    save: vi.fn(),
+    clear: vi.fn(),
+  };
+  (globalThis as { __workspaceLayoutRepositoryMock?: typeof repository }).__workspaceLayoutRepositoryMock = repository;
+  return {
+    getWorkspaceLayoutRepository: () => repository,
+  };
+});
+
+// Import after mocks are registered.
+import { useWorkspaceLayoutStore } from '@/modules/workspaceLayout/store';
+
+const mockRepository = (globalThis as {
+  __workspaceLayoutRepositoryMock: {
+    load: ReturnType<typeof vi.fn<[string], Promise<WorkspaceLayoutSnapshot | null>>>;
+    save: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+  };
+}).__workspaceLayoutRepositoryMock;
+
+function cloneDefaultLayout(): WorkspaceLayoutSnapshot {
+  return JSON.parse(JSON.stringify(DEFAULT_WORKSPACE_LAYOUT)) as WorkspaceLayoutSnapshot;
+}
+
+describe('workspace layout store', () => {
+  beforeEach(() => {
+    mockRepository.load.mockReset();
+    mockRepository.save.mockReset();
+    mockRepository.clear.mockReset();
+    useWorkspaceLayoutStore.setState((state) => ({
+      ...state,
+      layout: cloneDefaultLayout(),
+      hydratedForUserId: undefined,
+      pendingUserId: undefined,
+      hydrationRequestId: undefined,
+      isHydrating: false,
+      isSaving: false,
+      error: undefined,
+    }));
+  });
+
+  it('hydrates the latest user even when a previous request is still pending', async () => {
+    const pending = new Map<
+      string,
+      {
+        resolve: (value: WorkspaceLayoutSnapshot | null) => void;
+        reject: (reason?: unknown) => void;
+      }
+    >();
+
+    mockRepository.load.mockImplementation((userId: string) => {
+      return new Promise<WorkspaceLayoutSnapshot | null>((resolve, reject) => {
+        pending.set(userId, { resolve, reject });
+      });
+    });
+
+    const { actions } = useWorkspaceLayoutStore.getState();
+
+    const requestA = actions.hydrate('user_a');
+    expect(mockRepository.load).toHaveBeenCalledWith('user_a');
+
+    const requestB = actions.hydrate('user_b');
+    expect(mockRepository.load).toHaveBeenCalledWith('user_b');
+
+    pending.get('user_a')?.resolve({
+      version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+      columns: [
+        { id: 'left', panelIds: ['pipelineStatus'] },
+        { id: 'center', panelIds: [] },
+        { id: 'right', panelIds: [] },
+        { id: 'full', panelIds: [] },
+      ],
+    });
+    await requestA;
+
+    let state = useWorkspaceLayoutStore.getState();
+    expect(state.hydratedForUserId).not.toBe('user_a');
+    expect(state.pendingUserId).toBe('user_b');
+    expect(state.isHydrating).toBe(true);
+
+    pending.get('user_b')?.resolve({
+      version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+      columns: [
+        { id: 'left', panelIds: ['captureAudio'] },
+        { id: 'center', panelIds: [] },
+        { id: 'right', panelIds: ['ttsControls'] },
+        { id: 'full', panelIds: ['pipelineStatus'] },
+      ],
+    });
+    await requestB;
+
+    state = useWorkspaceLayoutStore.getState();
+    expect(state.hydratedForUserId).toBe('user_b');
+    expect(state.pendingUserId).toBeUndefined();
+    expect(state.isHydrating).toBe(false);
+
+    const leftColumn = state.layout.columns.find((column) => column.id === 'left');
+    expect(leftColumn?.panelIds).toContain('captureAudio');
+  });
+});


### PR DESCRIPTION
## Summary
- add server API for workspace layout persistence to keep Convex secrets server-side
- add client repository with offline fallback, user-switch hydration handling, and Tailwind config loading
- document web workspace layout behaviour and update tests

## Testing
- npm run test -- src/tests/unit/api/workspaceLayoutRoute.test.ts
- npm run test -- src/tests/unit/workspaceLayoutStore.test.ts
- npm run build